### PR TITLE
Add tests for argument, self, and super semantics

### DIFF
--- a/TestSuite/BasicInterpreterTests/Self.som
+++ b/TestSuite/BasicInterpreterTests/Self.som
@@ -1,0 +1,32 @@
+"
+Copyright (c) 2001-2018 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+Self = (
+    
+    ----
+    
+    assignSuper = (
+      super := 42.
+      ^ super
+    )
+
+)

--- a/TestSuite/CompilerReturnTest.som
+++ b/TestSuite/CompilerReturnTest.som
@@ -100,4 +100,13 @@ CompilerReturnTest = TestCase (
         (3 >= 1) ifTrue: [arr at: 2 put: 2 "WITHOUT DOT"].
         arr at: 3 put: 3.
     )
+
+    testWriteArgument = (
+        self assert: 42 equals: (self dec: 43).
+    )
+  
+    dec: anInt = (
+        anInt := anInt - 1.
+        ^ anInt
+    )
 )

--- a/TestSuite/SuperTest.som
+++ b/TestSuite/SuperTest.som
@@ -1,8 +1,6 @@
 "
 
-$Id: SuperTest.som 30 2009-07-31 12:20:25Z michael.haupt $
-
-Copyright (c) 2007-2013 see AUTHORS file
+Copyright (c) 2007-2018 see AUTHORS file
 Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
 http://www.hpi.uni-potsdam.de/swa/
 
@@ -42,5 +40,34 @@ SuperTest = SuperTestSuperClass (
   
   something = (
     ^ #sub
+  )
+  
+  testAssignSelf = (
+    | that |
+    "self should not be assignable.
+     Once this is enforced, we likely need to convert this into an
+     external test, or a BasicInterpreterTest, where we can check
+     an exception generated during parsing."
+    that := self.
+    self := 43.
+    that expect: that is: self.
+  )
+  
+  testGlobalSelfDoesNotShadowKeyword = (
+    | that |
+    that := self.
+    system global: #self put: 42.
+    that expect: that is: self.
+    
+    self assert: 42 equals: (system global: #self)
+  )
+  
+  testGlobalSuperDoesNotShadowKeyword = (
+    | that |
+    that := super.
+    system global: #super put: 42.
+    that expect: that is: super.
+    
+    self assert: 42 equals: (system global: #super)
   )
 )


### PR DESCRIPTION
This PR introduces some tests to codify the SOM language semantics around argument semantics and the self/super pseudo variables.

It is related to #6 and #7.