### PR TITLE
Add missing ".".

### DIFF
--- a/Examples/Benchmarks/LanguageFeatures/WhileLoopPoly.som
+++ b/Examples/Benchmarks/LanguageFeatures/WhileLoopPoly.som
@@ -27,7 +27,7 @@ WhileLoopPoly = Benchmark (
         sum := 0.
         [sum < 1000]
             whileTrue:
-                [sum := sum + 1
+                [sum := sum + 1.
                 ((sum % 4) = 0) ifTrue:  [poly := 1].
                 ((sum % 4) = 1) ifTrue:  [poly := 'abc'].
                 ((sum % 4) = 2) ifTrue:  [poly := 2222222222222222].


### PR DESCRIPTION
AFAICS this is accepted because of a probably unexpected quirk in the current parser: however I suspect that SOM users would probably expect the "." to be present.

I'm willing to be corrected on this: the current parser is a little hard to follow in places, and I may have misunderstood what it's intended / expected to do.