### PR TITLE
Test that tests are updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 
 # command to run tests
 script:
+  - ./TestSuite/BasicInterpreterTests/number-of-tests.sh
   - export ST_DIR=`pwd`/Smalltalk
   - cd som-vm
   - git --no-pager log -n 1

--- a/TestSuite/BasicInterpreterTests/Blocks.som
+++ b/TestSuite/BasicInterpreterTests/Blocks.som
@@ -24,18 +24,18 @@ Blocks = (
     
     ----
     
-    arg1 = ( ^ [:a | a - 1] value: 43 )
+    testArg1 = ( ^ [:a | a - 1] value: 43 )
 
-    arg2 = ( ^ [:a :b | a * b ] value: 11 with: 7 )
+    testArg2 = ( ^ [:a :b | a * b ] value: 11 with: 7 )
   
-    argAndLocal = (
+    testArgAndLocal = (
       ^ ([:a |
         | blockLocal | 
         blockLocal := 3.
         a + blockLocal] value: 5)
     )
     
-    argAndContext = ( | methodLocal |
+    testArgAndContext = ( | methodLocal |
       ^ ([:a |
         methodLocal := 3.
         a + methodLocal] value: 5)

--- a/TestSuite/BasicInterpreterTests/CompilerSimplification.som
+++ b/TestSuite/BasicInterpreterTests/CompilerSimplification.som
@@ -24,17 +24,17 @@ CompilerSimplification = (
     ----
     | aField |
     
-    returnConstantSymbol = ( ^ #constant )
-    returnConstantInt    = ( ^ 42 )
+    testReturnConstantSymbol = ( ^ #constant )
+    testReturnConstantInt    = ( ^ 42 )
     
-    returnSelf           = (^ self)
-    returnSelfImplicitly = ()
+    testReturnSelf           = (^ self)
+    testReturnSelfImplicitly = ()
     
-    returnArgument: n      = ( ^ n )
-    returnArgument: n a: a = ( ^ a )
+    testReturnArgument: n      = ( ^ n )
+    testReturnArgument: n a: a = ( ^ a )
     
-    testReturnArgumentN = ( ^ self returnArgument: 55 )
-    testReturnArgumentA = ( ^ self returnArgument: 55 a: 44 )
+    testReturnArgumentN = ( ^ self testReturnArgument: 55 )
+    testReturnArgumentA = ( ^ self testReturnArgument: 55 a: 44 )
     
     
     setField: val = ( aField := val )
@@ -45,7 +45,6 @@ CompilerSimplification = (
     )
     
     getField = (^ aField)
-    
     testGetField = (
         aField := 40.
         ^ self getField

--- a/TestSuite/BasicInterpreterTests/Hash.som
+++ b/TestSuite/BasicInterpreterTests/Hash.som
@@ -24,7 +24,7 @@ Hash = (
     
     ----
     
-    hashTest = (
+    testHash = (
         | ht string array t | 
     
         ht := Hashtable new.

--- a/TestSuite/BasicInterpreterTests/NonLocalReturn.som
+++ b/TestSuite/BasicInterpreterTests/NonLocalReturn.som
@@ -24,17 +24,6 @@ NonLocalReturn = (
     
     ----
     
-    test = (
-        'test1 expect 42: ' println.
-        self test1 asString println.
-        
-        'test2 expect 43: ' println.
-        self test2 asString println.
-        
-        'test3 expect  3: ' println.
-        self test3 asString println.
-    )
-    
     test1 = ( | t1Frame |
       [ | nlrFrame |
         ^ 42 ] value

--- a/TestSuite/BasicInterpreterTests/NonLocalVars.som
+++ b/TestSuite/BasicInterpreterTests/NonLocalVars.som
@@ -23,7 +23,7 @@ THE SOFTWARE.
 NonLocalVars = (
      ----
      
-     writeDifferentTypes = (
+     testWriteDifferentTypes = (
         | value |
         1 to: 10 do: [:index |
             value := 0.

--- a/TestSuite/BasicInterpreterTests/NumberOfTests.som
+++ b/TestSuite/BasicInterpreterTests/NumberOfTests.som
@@ -26,5 +26,5 @@ NumberOfTests = (
     
     "Return the known number of tests,
      should be used in basic interpreter test harness to confirm completeness"
-    numberOfTests = ( ^       51 )
+    numberOfTests = ( ^ 51 )
 )

--- a/TestSuite/BasicInterpreterTests/NumberOfTests.som
+++ b/TestSuite/BasicInterpreterTests/NumberOfTests.som
@@ -1,0 +1,30 @@
+"
+Copyright (c) 2019 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+NumberOfTests = (
+    
+    ----
+    
+    "Return the known number of tests,
+     should be used in basic interpreter test harness to confirm completeness"
+    numberOfTests = ( ^       34 )
+)

--- a/TestSuite/BasicInterpreterTests/NumberOfTests.som
+++ b/TestSuite/BasicInterpreterTests/NumberOfTests.som
@@ -26,5 +26,5 @@ NumberOfTests = (
     
     "Return the known number of tests,
      should be used in basic interpreter test harness to confirm completeness"
-    numberOfTests = ( ^       34 )
+    numberOfTests = ( ^       51 )
 )

--- a/TestSuite/BasicInterpreterTests/ObjectCreation.som
+++ b/TestSuite/BasicInterpreterTests/ObjectCreation.som
@@ -28,9 +28,10 @@ ObjectCreation = (
         | i |
         i := 0.
         
-        [i < 100000000] whileTrue: [
+        [i < 1000000] whileTrue: [
             self new.
             i := i + 1.
-        ]
+        ].
+        ^ i
     )
 )

--- a/TestSuite/BasicInterpreterTests/Return.som
+++ b/TestSuite/BasicInterpreterTests/Return.som
@@ -24,11 +24,11 @@ Return = (
     
     ----
     
-    returnSelf = ( ^ self )
+    testReturnSelf = ( ^ self )
 
-    returnSelfImplicitly = ( )
+    testReturnSelfImplicitly = ( )
   
-    noReturnReturnsSelf = ( 1 )
+    testNoReturnReturnsSelf = ( 1 )
     
-    blockReturnsImplicitlyLastValue = ( ^ ([4] value) )
+    testBlockReturnsImplicitlyLastValue = ( ^ ([4] value) )
 )

--- a/TestSuite/BasicInterpreterTests/Self.som
+++ b/TestSuite/BasicInterpreterTests/Self.som
@@ -24,9 +24,13 @@ Self = (
     
     ----
     
-    assignSuper = (
+    testAssignSuper = (
       super := 42.
       ^ super
     )
 
+    testAssignSelf = (
+      self := 42.
+      ^ self
+    )
 )

--- a/TestSuite/BasicInterpreterTests/number-of-tests.sh
+++ b/TestSuite/BasicInterpreterTests/number-of-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+SCRIPT_PATH=`dirname $0`
+TEST_FILE="${SCRIPT_PATH}/NumberOfTests.som"
+NUM_TESTS=`grep -R "test[^[:space:]]* = (" "${SCRIPT_PATH}" | wc -l`
+
+TEST_CODE="    numberOfTests = ( ^ ${NUM_TESTS} )"
+
+sed -i'.old' -e 's/.*numberOfTests.*/'"${TEST_CODE}/" "${TEST_FILE}"
+
+git --no-pager diff --exit-code "${TEST_FILE}"

--- a/TestSuite/BasicInterpreterTests/number-of-tests.sh
+++ b/TestSuite/BasicInterpreterTests/number-of-tests.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 SCRIPT_PATH=`dirname $0`
 TEST_FILE="${SCRIPT_PATH}/NumberOfTests.som"
-NUM_TESTS=`grep -R "test[^[:space:]]*[[:space:]]\+= (" "${SCRIPT_PATH}" | wc -l`
+
+# find all tests, count them, trim whitespace from result
+NUM_TESTS=`grep -R "test[^[:space:]]*[[:space:]]\+= (" "${SCRIPT_PATH}" | wc -l | tr -d '[:space:]'`
 
 TEST_CODE="    numberOfTests = ( ^ ${NUM_TESTS} )"
 

--- a/TestSuite/BasicInterpreterTests/number-of-tests.sh
+++ b/TestSuite/BasicInterpreterTests/number-of-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 SCRIPT_PATH=`dirname $0`
 TEST_FILE="${SCRIPT_PATH}/NumberOfTests.som"
-NUM_TESTS=`grep -R "test[^[:space:]]* = (" "${SCRIPT_PATH}" | wc -l`
+NUM_TESTS=`grep -R "test[^[:space:]]*[[:space:]]\+= (" "${SCRIPT_PATH}" | wc -l`
 
 TEST_CODE="    numberOfTests = ( ^ ${NUM_TESTS} )"
 


### PR DESCRIPTION
This PR adds some bits of infrastructure so that the basic interpreter tests can made to be fail automatically, if a new one was added and the test harness is not updated in a SOM implementation.

This is mostly to make sure we do not forget updating the test harnesses.