### PR TITLE
Remove testAssignSelf in SuperTest

### DIFF
--- a/TestSuite/SuperTest.som
+++ b/TestSuite/SuperTest.som
@@ -42,16 +42,7 @@ SuperTest = SuperTestSuperClass (
     ^ #sub
   )
   
-  testAssignSelf = (
-    | that |
-    "self should not be assignable.
-     Once this is enforced, we likely need to convert this into an
-     external test, or a BasicInterpreterTest, where we can check
-     an exception generated during parsing."
-    that := self.
-    self := 43.
-    that expect: that is: self.
-  )
+  "Note: testing assigning self was moved to basic interpreter tests"
   
   testGlobalSelfDoesNotShadowKeyword = (
     | that |


### PR DESCRIPTION
This is now covered in the basic interpreter tests, which are easier to use to test for parse errors

Signed-off-by: Stefan Marr <git@stefan-marr.de>