### PR TITLE
Added test for #ticks primitive and class loading issue

### DIFF
--- a/TestSuite/ClassStructureTest.som
+++ b/TestSuite/ClassStructureTest.som
@@ -14,6 +14,10 @@ ClassStructureTest = TestCase (
     self assert: True    equals: true class.
     self assert: False   equals: false class.
     self assert: Nil     equals: nil class.
+    
+    self assert: True superclass equals: False superclass.
+    self assert: True superclass equals: Boolean.
+    self assert: True superclass equals: Boolean.
   )
     
   testThatCertainMethodsArePrimitives = (

--- a/TestSuite/SystemTest.som
+++ b/TestSuite/SystemTest.som
@@ -5,4 +5,11 @@ SystemTest = TestCase (
      to indicate the a GC was done."
     self expect: system fullGC description: 'VM does not support #fullGC.'
   )
+  
+  testTicks = (
+    | ticks |
+    ticks := system ticks.
+    self assert: ticks class equals: Integer.
+    self assert: ticks > 0 description: 'Should return the microseconds since the start'
+  )
 )


### PR DESCRIPTION
- basic test to ensure `System>>#ticks` primitive is available
- test to ensure that class loading is correct and does not lead to identity issues because of loading classes repeatedly