### PR TITLE
Implement SomSom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,3 +144,10 @@ jobs:
       
           echo "${{ matrix.som }} $SOM_TESTS"
           eval "${{ matrix.som }} $SOM_TESTS"
+
+      # We currently test SomSom only on TruffleSOM
+      - name: Test SomSom on TruffleSOM
+        if: ${{ matrix.repo == 'TruffleSOM.git' }}
+        run: |
+          cd som-vm
+          ${{ matrix.som }} -cp ../Smalltalk:../TestSuite:../SomSom/src/compiler:../SomSom/src/interpreter:../SomSom/src/primitives:../SomSom/src/vm:../SomSom/src/vmobjects  ../SomSom/tests/SomSomTests.som

--- a/Smalltalk/System.som
+++ b/Smalltalk/System.som
@@ -73,7 +73,7 @@ System = (
                 self global: (current_class name) put: current_class.
                 current_class := current_class superclass. ].
             ^class ].
-        self error: 'Unable to resolve ' + symbol
+        self error: 'Tried loading "' + symbol + '" as a class, but failed.'
     )
 
     "Exiting"

--- a/SomSom/src/compiler/BytecodeGenerator.som
+++ b/SomSom/src/compiler/BytecodeGenerator.som
@@ -1,0 +1,86 @@
+BytecodeGenerator = (
+  ----
+  emitPop: mgenc = (
+    self emit: mgenc bc: #pop
+  )
+
+  emit: mgenc pushArgument: idx in: ctx = (
+    self emit: mgenc bc: #pushArgument with: idx and: ctx
+  )
+
+  emitReturnLocal: mgenc = (
+    self emit: mgenc bc: #returnLocal
+  )
+
+  emitReturnNonLocal: mgenc = (
+    self emit: mgenc bc: #returnNonLocal
+  )
+
+  emitDup: mgenc = (
+    self emit: mgenc bc: #dup
+  )
+
+  emit: mgenc pushBlock: blockMethod = (
+    self emit: mgenc bc: #pushBlock with: (mgenc addLiteralIfAbsent: blockMethod)
+  )
+
+  emit: mgenc pushLocal: idx in: ctx = (
+    idx negative ifTrue: [ self error: 'pushLocal: ' + idx asString].
+    self emit: mgenc bc: #pushLocal with: idx and: ctx
+  )
+
+  emit: mgenc pushField: aSymbol = (
+    (mgenc hasField: aSymbol) ifFalse: [ self error: 'pushField: field unknown ' + aSymbol ].
+    self emit: mgenc bc: #pushField with: (mgenc fieldIndex: aSymbol)
+  )
+
+  emit: mgenc pushGlobal: aSymbol = (
+    self emit: mgenc bc: #pushGlobal with: (mgenc addLiteralIfAbsent: aSymbol)
+  )
+
+  emit: mgenc popArgument: idx in: ctx = (
+    idx negative ifTrue: [ self error: 'popArgument: ' + idx asString].
+    self emit: mgenc bc: #popArgument with: idx and: ctx
+  )
+
+  emit: mgenc popLocal: idx in: ctx = (
+    idx negative ifTrue: [ self error: 'popLocal: ' + idx asString].
+    self emit: mgenc bc: #popLocal with: idx and: ctx
+  )
+
+  emit: mgenc popField: aSymbol = (
+    (mgenc hasField: aSymbol) ifFalse: [ self error: 'popField: field unknown ' + aSymbol ].
+    self emit: mgenc bc: #popField with: (mgenc fieldIndex: aSymbol)
+  )
+
+  emit: mgenc superSend: aSymbol = (
+    self emit: mgenc bc: #superSend with: (mgenc addLiteralIfAbsent: aSymbol)
+  )
+
+  emit: mgenc send: aSymbol = (
+    self emit: mgenc bc: #send with: (mgenc addLiteralIfAbsent: aSymbol)
+  )
+
+  emit: mgenc pushConstant: anAbstractObject = (
+    self emit: mgenc bc: #pushConstant with: (mgenc addLiteralIfAbsent: anAbstractObject)
+  )
+
+  emit: mgenc pushConstantIdx: anInteger = (
+    self emit: mgenc bc: #pushConstant with: anInteger
+  )
+
+  emit: mgenc bc: aSymbol = (
+    mgenc addBytecode: aSymbol.
+  )
+
+  emit: mgenc bc: aSymbol with: anInteger = (
+    mgenc addBytecode: aSymbol.
+    mgenc addBytecode: anInteger.
+  )
+
+  emit: mgenc bc: aSymbol with: anInteger and: otherInteger = (
+    mgenc addBytecode: aSymbol.
+    mgenc addBytecode: anInteger.
+    mgenc addBytecode: otherInteger.
+  )
+)

--- a/SomSom/src/compiler/ClassGenerationContext.som
+++ b/SomSom/src/compiler/ClassGenerationContext.som
@@ -1,0 +1,20 @@
+ClassGenerationContext = (
+  | universe superName |
+  initalize: aUniverse = (
+    universe := aUniverse
+  )
+
+  superName = (
+    ^ superName
+  )
+
+  superName: aSymbol = (
+    superName := aSymbol
+  )
+
+  ----
+
+  new: aUniverse = (
+    ^ self new initalize: aUniverse
+  )
+)

--- a/SomSom/src/compiler/ClassGenerationContext.som
+++ b/SomSom/src/compiler/ClassGenerationContext.som
@@ -1,6 +1,6 @@
 ClassGenerationContext = (
   | universe
-    superName
+    name superName
     classSide
     classFields instanceFields
     classMethods instanceMethods |
@@ -14,12 +14,34 @@ ClassGenerationContext = (
     instanceMethods := Vector new.
   )
 
+  name = (
+    ^ name
+  )
+
+  name: aSSymbol = (
+    name := aSSymbol
+  )
+
   superName = (
     ^ superName
   )
 
   superName: aSymbol = (
     superName := aSymbol
+  )
+
+  instanceFieldsOfSuper: aSArrayOfFieldNames = (
+    | numFields |
+    numFields := aSArrayOfFieldNames numberOfIndexableFields.
+    1 to: numFields do: [:i |
+      instanceFields append: (aSArrayOfFieldNames indexableField: i) ]
+  )
+
+  classFieldsOfSuper: aSArrayOfFieldNames = (
+    | numFields |
+    numFields := aSArrayOfFieldNames numberOfIndexableFields.
+    1 to: numFields do: [:i |
+      classFields append: (aSArrayOfFieldNames indexableField: i) ]
   )
 
   addField: aSymbol = (
@@ -48,6 +70,50 @@ ClassGenerationContext = (
 
   startClassSide = (
     classSide := true
+  )
+
+  assemble = (
+    | ccname superClass resultClass superMClass result |
+    "build class class name"
+    ccname := name string + ' class'.
+
+    "Load the super class"
+    superClass := universe loadClass: superName.
+
+    "Allocate the class of the resulting class"
+    resultClass := universe newClass: universe metaclassClass.
+
+    "Initialize the class of the resulting class"
+    resultClass instanceFields: (universe newArrayFromVector: classFields).
+    resultClass instanceInvokables: (universe newArrayFromVector: classMethods).
+    resultClass name: (universe symbolFor: ccname).
+
+    superMClass := superClass somClass.
+    resultClass superClass: superMClass.
+
+    "Allocate the resulting class"
+    result := universe newClass: resultClass.
+
+    "Initialize the resulting class"
+    result name: name.
+    result superClass: superClass.
+    result instanceFields: (universe newArrayFromVector: instanceFields).
+    result instanceInvokables: (universe newArrayFromVector: instanceMethods).
+
+    ^ result
+  )
+
+  assembleSystemClass: systemClass = (
+    | superMClass |
+    systemClass instanceInvokables: (universe newArrayFromVector: instanceMethods).
+    systemClass instanceFields: (universe newArrayFromVector: instanceFields).
+
+    "class-bound == class-instance-bound"
+    superMClass := systemClass somClass.
+    superMClass instanceInvokables: (universe newArrayFromVector: classMethods).
+    superMClass instanceFields: (universe newArrayFromVector: classFields).
+
+    ^ systemClass
   )
 
   ----

--- a/SomSom/src/compiler/ClassGenerationContext.som
+++ b/SomSom/src/compiler/ClassGenerationContext.som
@@ -1,7 +1,17 @@
 ClassGenerationContext = (
-  | universe superName |
+  | universe
+    superName
+    classSide
+    classFields instanceFields
+    classMethods instanceMethods |
+
   initalize: aUniverse = (
-    universe := aUniverse
+    universe := aUniverse.
+    classSide := false.
+    classFields := Vector new.
+    instanceFields := Vector new.
+    classMethods := Vector new.
+    instanceMethods := Vector new.
   )
 
   superName = (
@@ -10,6 +20,18 @@ ClassGenerationContext = (
 
   superName: aSymbol = (
     superName := aSymbol
+  )
+
+  addField: aSymbol = (
+    classSide
+      ifTrue: [classFields append: aSymbol]
+      ifFalse: [instanceFields append: aSymbol]
+  )
+
+  addMethod: anInvokable = (
+    classSide
+      ifTrue: [classMethods append: anInvokable]
+      ifFalse: [instanceMethods append: anInvokable]
   )
 
   ----

--- a/SomSom/src/compiler/ClassGenerationContext.som
+++ b/SomSom/src/compiler/ClassGenerationContext.som
@@ -28,10 +28,26 @@ ClassGenerationContext = (
       ifFalse: [instanceFields append: aSymbol]
   )
 
+  hasField: aSymbol = (
+    ^ classSide
+      ifTrue: [classFields contains: aSymbol]
+      ifFalse: [instanceFields contains: aSymbol]
+  )
+
+  fieldIndex: aSymbol = (
+    ^ classSide
+      ifTrue: [classFields indexOf: aSymbol]
+      ifFalse: [instanceFields indexOf: aSymbol]
+  )
+
   addMethod: anInvokable = (
     classSide
       ifTrue: [classMethods append: anInvokable]
       ifFalse: [instanceMethods append: anInvokable]
+  )
+
+  startClassSide = (
+    classSide := true
   )
 
   ----

--- a/SomSom/src/compiler/Disassembler.som
+++ b/SomSom/src/compiler/Disassembler.som
@@ -1,0 +1,112 @@
+Disassembler = (
+
+  ----
+
+  dump: cl in: universe = (
+    1 to: cl numberOfInstanceInvokables do: [:i |
+      | inv |
+      inv := cl instanceInvokable: i.
+
+      "output header and skip if the Invokable is a Primitive"
+      Universe errorPrint: (cl name string + '>>' + inv signature string + ' = ').
+
+      inv isPrimitive
+        ifTrue: [ Universe errorPrintln: '<primitive>' ]
+        ifFalse: [ self dumpMethod: inv indent: '\t' in: universe ] ]
+  )
+
+  dumpInvokable: inv in: universe = (
+    | holderName |
+    holderName := inv holder == nil
+      ifTrue: ['nil']
+      ifFalse: [inv holder name string].
+    Universe errorPrint: (holderName + '>>#' + inv signature string + ' = ').
+    inv isPrimitive
+        ifTrue: [
+          Universe errorPrint: '<primitive>: '.
+          Universe errorPrintln: inv debugString ]
+        ifFalse: [ self dumpMethod: inv indent: '\t' in: universe ]
+  )
+
+  dumpMethod: m indent: indent in: universe = (
+    | b |
+    Universe errorPrintln: '('.
+
+    "output stack information"
+    Universe errorPrintln: indent + '<' + m numberOfLocals + ' locals, '
+        + m maximumNumberOfStackElements + ' stack, '
+        + m numberOfBytecodes + ' bc_count>'.
+
+    "output bytecodes"
+    b := 1.
+    [b <= m numberOfBytecodes] whileTrue: [
+      | bytecode |
+      Universe errorPrint: indent.
+
+      b < 10 ifTrue: [ Universe errorPrint: ' ' ].
+      b < 100 ifTrue: [ Universe errorPrint: ' ' ].
+
+      Universe errorPrint: ' ' + b + ':'.
+
+      "mnemonic"
+      bytecode := m bytecode: b.
+      Universe errorPrint: (Bytecodes paddedBytecodeName: bytecode) + '  '.
+
+      "parameters (if any)"
+      (Bytecodes length: bytecode) = 1
+        ifTrue: [ Universe errorPrintln ]
+        ifFalse: [ self dumpBytecode: bytecode idx: b method: m indent: indent in: universe ].
+
+      b := b + (Bytecodes length: (m bytecode: b)) ].
+
+    Universe errorPrintln: indent + ')'
+  )
+
+  dumpBytecode: bc idx: b method: m indent: indent in: universe = (
+    bc == #pushLocal ifTrue: [
+      Universe errorPrintln: 'local: ' + (m bytecode: b + 1) + ', context: ' + (m bytecode: b + 2).
+      ^ self ].
+    bc == #pushArgument ifTrue: [
+      Universe errorPrintln: 'argument: ' + (m bytecode: b + 1) + ', context: ' + (m bytecode: b + 2).
+      ^ self ].
+    bc == #pushField ifTrue: [
+      | idx fieldName |
+      idx := m bytecode: b + 1.
+      fieldName := (m holder instanceFields indexableField: idx) string.
+      Universe errorPrintln: '(index: ' + idx + ') field: ' + fieldName.
+      ^ self ].
+    bc == #pushBlock ifTrue: [
+      Universe errorPrint: '(block: (index: ' + (m bytecode: b + 1) + ') '.
+      self dumpMethod: (m constant: b) indent: indent + '\t' in: universe.
+      ^ self ].
+    bc == #pushConstant ifTrue: [
+      | constant |
+      constant := m constant: b.
+      Universe errorPrintln: '(index: ' + (m bytecode: b + 1) + ') value: '
+        + '(' + (constant somClassIn: universe) name string + ') ' + constant debugString.
+      ^ self ].
+    bc == #pushGlobal ifTrue: [
+      Universe errorPrintln: '(index: ' + (m bytecode: b + 1) + ') value: #' + (m constant: b) string.
+      ^ self ].
+    bc == #popLocal ifTrue: [
+      Universe errorPrintln: 'local: ' + (m bytecode: b + 1) + ', context: ' + (m bytecode: b + 2).
+      ^ self ].
+    bc == #popArgument ifTrue: [
+      Universe errorPrintln: 'argument: ' + (m bytecode: b + 1) + ', context: ' + (m bytecode: b + 2).
+      ^ self ].
+    bc == #pushField ifTrue: [
+      | idx fieldName |
+      idx := m bytecode: b + 1.
+      fieldName := (m holder instanceFields indexableField: idx) string.
+      Universe errorPrintln: '(index: ' + idx + ') field: ' + fieldName.
+      ^ self ].
+    bc == #send ifTrue: [
+      Universe errorPrintln: '(index: ' + (m bytecode: b + 1) + ') signature: #' + (m constant: b) string.
+      ^ self ].
+    bc == #superSend ifTrue: [
+      Universe errorPrintln: '(index: ' + (m bytecode: b + 1) + ') signature: #' + (m constant: b) string.
+      ^ self ].
+
+    Universe errorPrintln: '<unknown bytecode>'
+  )
+)

--- a/SomSom/src/compiler/Lexer.som
+++ b/SomSom/src/compiler/Lexer.som
@@ -14,6 +14,13 @@ Lexer = (
   isPeekDone = ( ^ peekDone )
   text = ( ^ text )
 
+  currentTextContext = (
+    | start end |
+    start := (index - 50) max: 1.
+    end := (index + 5) min: fileContent length.
+    ^ fileContent substringFrom: start to: end
+  )
+
   peek = (
     | savedSym savedText |
     peekDone ifTrue: [

--- a/SomSom/src/compiler/Lexer.som
+++ b/SomSom/src/compiler/Lexer.som
@@ -1,0 +1,285 @@
+Lexer = (
+  | fileContent state stateAfterPeek peekDone
+    index
+    sym text
+    nextSym nextText
+  |
+
+  initialize: aString = (
+    fileContent := aString.
+    peekDone := false.
+    index := 1.
+  )
+
+  peekDone = ( ^ peekDone )
+  text = ( ^ text )
+
+  peek = (
+    | savedSym savedText |
+    peekDone ifTrue: [
+      self error: 'SOM lexer cannot peek twice. Likely parser bug' ].
+
+    savedSym := sym.
+    savedText := text.
+    self sym.
+
+    nextSym := sym.
+    nextText := text.
+    peekDone := true.
+
+    sym := savedSym.
+    text := savedText.
+
+    ^ nextSym
+  )
+
+  sym = (
+    peekDone ifTrue: [
+      peekDone := false.
+      sym := nextSym.
+      text := nextText.
+      ^ sym ].
+
+    self hasMoreInput ifFalse: [
+      sym := #NONE.
+      text := nil.
+      ^ sym ].
+
+    [self currentChar isWhiteSpace or: [self currentChar = '"']] whileTrue: [
+      self skipWhiteSpace.
+      self skipComment ].
+
+    self currentChar = '\'' ifTrue: [
+      ^ self lexString ].
+    self currentChar = '[' ifTrue: [
+      ^ self match: #newBlock ].
+    self currentChar = ']' ifTrue: [
+      ^ self match: #endBlock ].
+
+    self currentChar = ':' ifTrue: [
+      self nextChar = '='
+        ifTrue: [
+          index := index + 2.
+          sym := #assign.
+          text := ':=' ]
+        ifFalse: [
+          index := index + 1.
+          sym := #colon.
+          text := ':'
+        ].
+      ^ sym ].
+
+    self currentChar = '(' ifTrue: [
+      ^ self match: #newTerm ].
+    self currentChar = ')' ifTrue: [
+      ^ self match: #endTerm ].
+    self currentChar = '#' ifTrue: [
+      ^ self match: #pound ].
+    self currentChar = '^' ifTrue: [
+      ^ self match: #exit ].
+    self currentChar = '.' ifTrue: [
+      ^ self match: #period ].
+    self currentChar = '-' ifTrue: [
+      (self currentMatches: Lexer sepStr)
+        ifTrue: [
+          text := ''.
+          [self currentChar = '-'] whileTrue: [
+            text := text + self currentChar.
+            index := index + 1 ].
+
+          ^ sym := #separator ]
+        ifFalse: [
+          ^ self lexOperator ] ].
+    (Lexer isOperator: self currentChar) ifTrue: [
+      ^ self lexOperator ].
+    (self currentMatches: Lexer primStr) ifTrue: [
+      index := index + Lexer primStr length.
+      text := Lexer primStr.
+      ^ sym := #primitive ].
+    self currentChar isLetters ifTrue: [
+      text := ''.
+      [self currentChar isLetters or: [self currentChar isDigits or: [self currentChar = '_']]] whileTrue: [
+        text := text + self currentChar.
+        index := index + 1 ].
+      sym := #identifier.
+
+      self currentChar = ':' ifTrue: [
+        sym := #keyword.
+        index := index + 1.
+        text := text + ':'.
+        self currentChar isLetters ifTrue: [
+          sym := #keywordSequence.
+          [self currentChar isLetters or: [self currentChar = ':']] whileTrue: [
+            text := text + self currentChar.
+            index := index + 1 ] ] ].
+      ^ sym ].
+    self currentChar isDigits ifTrue: [
+      ^ self lexNumber ].
+
+    text := self currentChar.
+    ^ sym := #NONE
+  )
+
+  lexNumber = (
+    | sawDecimalMark |
+    sym := #integer.
+    text := ''.
+
+    sawDecimalMark := false.
+
+    [self currentChar isDigits] whileTrue: [
+      text := text + self currentChar.
+      index := index + 1.
+      (sawDecimalMark not and: [
+        self currentChar = '.' and: [
+          self nextChar isDigits]]) ifTrue: [
+        sym := #double.
+        text := text + self currentChar.
+        index := index + 1 ] ].
+    ^ sym
+  )
+
+  lexEscapeChar = (
+    self currentChar = 't' ifTrue: [ ^ text := text + '\t' ].
+    self currentChar = 'b' ifTrue: [ ^ text := text + '\b' ].
+    self currentChar = 'n' ifTrue: [ ^ text := text + '\n' ].
+    self currentChar = 'r' ifTrue: [ ^ text := text + '\r' ].
+    self currentChar = 'f' ifTrue: [ ^ text := text + '\f' ].
+    self currentChar = '\'' ifTrue: [ ^ text := text + '\'' ].
+    self currentChar = '\\' ifTrue: [ ^ text := text + '\\' ].
+    self currentChar = '0' ifTrue: [ ^ text := text + '\0' ].
+
+    self error: 'Unknown escape sequence \\' + self currentChar
+  )
+
+  lexStringChar = (
+    self currentChar = '\\'
+      ifTrue: [
+        index := index + 1.
+        self lexEscapeChar.
+        index := index + 1 ]
+      ifFalse: [
+        text := text + self currentChar.
+        index := index + 1 ]
+  )
+
+  lexString = (
+    sym := #string.
+    text := ''.
+    index := index + 1.
+
+    [self currentChar = '\''] whileFalse: [
+      self lexStringChar ].
+
+    index := index + 1.
+    ^ sym
+  )
+
+  lexOperator = (
+    (Lexer isOperator: self nextChar) ifTrue: [
+      text := ''.
+      [Lexer isOperator: self currentChar] whileTrue: [
+        text := text + self currentChar.
+        index := index + 1 ].
+      ^ sym := #operatorSequence ].
+    self currentChar = '~' ifTrue: [
+      ^ self match: #not ].
+    self currentChar = '&' ifTrue: [
+      ^ self match: #and ].
+    self currentChar = '|' ifTrue: [
+      ^ self match: #or ].
+    self currentChar = '*' ifTrue: [
+      ^ self match: #star ].
+    self currentChar = '/' ifTrue: [
+      ^ self match: #div ].
+    self currentChar = '\\' ifTrue: [
+      ^ self match: #mod ].
+    self currentChar = '+' ifTrue: [
+      ^ self match: #plus ].
+    self currentChar = '=' ifTrue: [
+      ^ self match: #equal ].
+    self currentChar = '>' ifTrue: [
+      ^ self match: #more ].
+    self currentChar = '<' ifTrue: [
+      ^ self match: #less ].
+    self currentChar = ',' ifTrue: [
+      ^ self match: #comma ].
+    self currentChar = '@' ifTrue: [
+      ^ self match: #at ].
+    self currentChar = '%' ifTrue: [
+      ^ self match: #per ].
+    self currentChar = '-' ifTrue: [
+      ^ self match: #minus ].
+    self error: 'lexOperator ran out of options. This should not happen'
+  )
+
+  skipWhiteSpace = (
+    [self currentChar isWhiteSpace] whileTrue: [
+      index := index + 1 ]
+  )
+
+  skipComment = (
+    self currentChar = '"'
+      ifFalse: [ ^ self ].
+
+    index := index + 1.
+
+    [self currentChar = '"'] whileFalse: [
+      index := index + 1 ].
+
+    index := index + 1
+  )
+
+  currentChar = (
+    index > fileContent length ifTrue: [ ^ '\0' ].
+    ^ fileContent charAt: index
+  )
+
+  nextChar = (
+    (index + 1) > fileContent length ifTrue: [ ^ '\0' ].
+    ^ fileContent charAt: index + 1
+  )
+
+  hasMoreInput = (
+    ^ index <= fileContent length
+  )
+
+  currentMatches: str = (
+    (index + str length) <= fileContent length ifFalse: [ ^ false ].
+    ^ str = (fileContent substringFrom: index to: index - 1 + str length)
+  )
+
+  match: s = (
+    sym := s.
+    text := self currentChar.
+    index := index + 1.
+    ^ sym
+  )
+
+  ----
+
+  new: aString = (
+    ^ self new initialize: aString
+  )
+
+  isOperator: c = (
+    c = '~' ifTrue: [ ^ true ].
+    c = '&' ifTrue: [ ^ true ].
+    c = '|' ifTrue: [ ^ true ].
+    c = '*' ifTrue: [ ^ true ].
+    c = '/' ifTrue: [ ^ true ].
+    c = '\\' ifTrue: [ ^ true ].
+    c = '+' ifTrue: [ ^ true ].
+    c = '=' ifTrue: [ ^ true ].
+    c = '>' ifTrue: [ ^ true ].
+    c = '<' ifTrue: [ ^ true ].
+    c = ',' ifTrue: [ ^ true ].
+    c = '@' ifTrue: [ ^ true ].
+    c = '%' ifTrue: [ ^ true ].
+    c = '-' ifTrue: [ ^ true ].
+    ^ false
+  )
+
+  sepStr  = ( ^ '----' )
+  primStr = ( ^ 'primitive' )
+)

--- a/SomSom/src/compiler/Lexer.som
+++ b/SomSom/src/compiler/Lexer.som
@@ -11,7 +11,7 @@ Lexer = (
     index := 1.
   )
 
-  peekDone = ( ^ peekDone )
+  isPeekDone = ( ^ peekDone )
   text = ( ^ text )
 
   peek = (

--- a/SomSom/src/compiler/MethodGenerationContext.som
+++ b/SomSom/src/compiler/MethodGenerationContext.som
@@ -115,6 +115,10 @@ MethodGenerationContext = (
     bytecode remove
   )
 
+  hasBytecodes = (
+    ^ bytecode isEmpty not
+  )
+
   hasField: aSymbol = (
     ^ holderGenc hasField: aSymbol
   )

--- a/SomSom/src/compiler/MethodGenerationContext.som
+++ b/SomSom/src/compiler/MethodGenerationContext.som
@@ -1,12 +1,24 @@
 MethodGenerationContext = (
-  | holderGenc outerGenc arguments signature finished prim |
+  | holderGenc outerGenc
+    arguments locals literals
+    signature
+    finished prim blockMethod
+    bytecode |
 
   initializeWith: aHolderGenc and: aOuterGenc = (
     holderGenc := aHolderGenc.
     outerGenc := aOuterGenc.
     arguments := Vector new.
+    locals := Vector new.
+    literals := Vector new.
     finished := false.
     prim := false.
+    blockMethod := false.
+    bytecode := Vector new.
+  )
+
+  holder = (
+    ^ holderGenc
   )
 
   signature: aSymbol = (
@@ -25,6 +37,58 @@ MethodGenerationContext = (
     ^ true
   )
 
+  numberOfArguments = (
+    ^ arguments size
+  )
+
+  addLocalIfAbsent: aString = (
+    (locals contains: aString)
+      ifTrue: [^ false].
+
+    locals append: aString.
+    ^ true
+  )
+
+  addLiteralIfAbsent: anAbstractObject = (
+    | idx |
+    idx := literals indexOf: anAbstractObject.
+    idx <> -1 ifTrue: [
+      ^ idx ].
+
+    ^ self addLiteral: anAbstractObject
+  )
+
+  addLiteral: anAbstractObject = (
+    | idx |
+    idx := literals size + 1.
+    literals append: anAbstractObject.
+    ^ idx
+  )
+
+  updateLiteral: oldVal at: idx put: newVal = (
+    (literals at: idx) == oldVal ifFalse: [
+      self error: 'updateLiteral saw wrong oldVal, indicates bug in parser' ].
+    literals at: idx put: newVal
+  )
+
+  findVar: var with: searchResult = (
+    "searchResult: index, context, isArgument"
+    searchResult at: 1 put: (locals indexOf: var).
+    (searchResult at: 1) = -1 ifTrue: [
+      searchResult at: 1 put: (arguments indexOf: var).
+      (searchResult at: 1) = -1
+        ifTrue: [
+          outerGenc == nil
+            ifTrue: [^ false]
+            ifFalse: [
+              searchResult at: 2 put: (searchResult at: 2) + 1.
+              ^ outerGenc findVar: var with: searchResult ] ]
+        ifFalse: [
+          searchResult at: 3 put: true ] ].
+
+    ^ true
+  )
+
   markAsFinished = (
     finished := true
   )
@@ -37,8 +101,38 @@ MethodGenerationContext = (
     prim := true
   )
 
+  isBlockMethod = (
+    ^ blockMethod
+  )
+
+  markAsBlockMethod = (
+    blockMethod := true
+  )
+
+  addBytecode: code = (
+    bytecode append: code
+  )
+
+  removeLastBytecode = (
+    bytecode remove
+  )
+
+  hasField: aSymbol = (
+    ^ holderGenc hasField: aSymbol
+  )
+
+  fieldIndex: aSymbol = (
+    ^ holderGenc fieldIndex: aSymbol
+  )
+
   assemble: universe = (
     'TODO: MGC assemble' println.
+    "TODO: need to implement."
+    ^ nil
+  )
+
+  assembleMethod: universe = (
+    'TODO: MGC assembleMethod' println.
     "TODO: need to implement."
     ^ nil
   )

--- a/SomSom/src/compiler/MethodGenerationContext.som
+++ b/SomSom/src/compiler/MethodGenerationContext.som
@@ -59,10 +59,8 @@ MethodGenerationContext = (
   )
 
   addLiteral: anAbstractObject = (
-    | idx |
-    idx := literals size + 1.
     literals append: anAbstractObject.
-    ^ idx
+    ^ literals size
   )
 
   updateLiteral: oldVal at: idx put: newVal = (
@@ -126,15 +124,80 @@ MethodGenerationContext = (
   )
 
   assemble: universe = (
-    'TODO: MGC assemble' println.
-    "TODO: need to implement."
-    ^ nil
+    prim
+      ifTrue: [
+        ^ SPrimitive emptyPrimitive: signature string in: universe ]
+      ifFalse: [
+        ^ self assembleMethod: universe ]
   )
 
   assembleMethod: universe = (
-    'TODO: MGC assembleMethod' println.
-    "TODO: need to implement."
-    ^ nil
+    | numLocals meth i |
+    "create a method instance with the given number of bytecodes"
+    numLocals := locals size.
+
+    meth := universe newMethod: signature
+        bc: bytecode asArray literals: literals asArray
+        numLocals: numLocals maxStack: self computeStackDepth.
+
+    "return the method - the holder field is to be set later on!"
+    ^ meth
+  )
+
+  computeStackDepth = (
+    | depth maxDepth i |
+    depth := 0.
+    maxDepth := 0.
+    i := 1.
+
+    [i <= bytecode size] whileTrue: [
+      | bc |
+      bc := bytecode at: i.
+
+      bc == #halt ifTrue: [
+        i := i + 1 ] ifFalse: [
+      bc == #dup  ifTrue: [
+        depth := depth + 1.
+        i := i + 1. ] ifFalse: [
+      (bc == #pushLocal or: [
+       bc == #pushArgument]) ifTrue: [
+          depth := depth + 1.
+          i := i + 3. ] ifFalse: [
+       (bc == #pushField or: [
+        bc == #pushBlock or: [
+        bc == #pushConstant or: [
+        bc == #pushGlobal ] ] ]) ifTrue: [
+           depth := depth + 1.
+           i := i + 2. ] ifFalse: [
+      bc == #pop ifTrue: [
+        depth := depth - 1.
+        i := i + 1. ] ifFalse: [
+      (bc == #popLocal or: [
+       bc == #popArgument ]) ifTrue: [
+          depth := depth - 1.
+          i := i + 3. ] ifFalse: [
+      bc == #popField ifTrue: [
+        depth := depth - 1.
+        i := i + 2. ] ifFalse: [
+      (bc == #send or: [bc == #superSend]) ifTrue: [
+        | sig |
+        "these are special: they need to look at the number of
+         arguments (extractable from the signature)"
+        sig := literals at: (bytecode at: i + 1).
+        depth := depth - sig numberOfSignatureArguments.
+        depth := depth + 1. "return value"
+        i := i + 2 ] ifFalse: [
+      (bc == #returnLocal or: [
+       bc == #returnNonLocal ]) ifTrue: [
+          i := i + 1. ]
+      ifFalse: [
+        self error: 'Illegal bytecode ' + bc asString
+      ] ] ] ] ] ] ] ] ].
+
+      depth > maxDepth ifTrue: [
+        maxDepth := depth ] ].
+
+    ^ maxDepth
   )
 
   ----

--- a/SomSom/src/compiler/MethodGenerationContext.som
+++ b/SomSom/src/compiler/MethodGenerationContext.som
@@ -1,0 +1,55 @@
+MethodGenerationContext = (
+  | holderGenc outerGenc arguments signature finished prim |
+
+  initializeWith: aHolderGenc and: aOuterGenc = (
+    holderGenc := aHolderGenc.
+    outerGenc := aOuterGenc.
+    arguments := Vector new.
+    finished := false.
+    prim := false.
+  )
+
+  signature: aSymbol = (
+    signature := aSymbol
+  )
+
+  addArgument: aString = (
+    arguments append: aString
+  )
+
+  addArgumentIfAbsent: aString = (
+    (arguments contains: aString)
+      ifTrue: [^ false].
+
+    arguments append: aString.
+    ^ true
+  )
+
+  markAsFinished = (
+    finished := true
+  )
+
+  isFinished = (
+    ^ finished
+  )
+
+  markAsPrimitive = (
+    prim := true
+  )
+
+  assemble: universe = (
+    'TODO: MGC assemble' println.
+    "TODO: need to implement."
+    ^ nil
+  )
+
+  ----
+
+  new: holderGenc = (
+    ^ self new initializeWith: holderGenc and: nil
+  )
+
+  new: holderGenc with: outerGenc = (
+    ^ self new initializeWith: holderGenc and: outerGenc
+  )
+)

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -592,7 +592,21 @@ Parser = (
   expect: s = (
     (self accept: s) ifTrue: [ ^ true ].
 
-    self error: 'Parsing failed, expected ' + s + ' but found ' + sym + ' (' + text + ')'
+    self error: 'Parsing of ' + filename + ' failed, expected ' + s + ' but found ' + sym +
+      ' (' + text + ').\nCurrent parser context: ' + lexer currentTextContext
+  )
+
+  expectOneOf: ss = (
+    | err |
+    (self acceptOneOf: ss) ifTrue: [ ^ true ].
+
+    err := 'Parsing of ' + filename + ' failed, expected one of '.
+
+    ss do: [
+      err := err + s + ', ' ].
+    err := err + 'but found: ' + sym + ' (' + text + ').\nCurrent parser context: ' + lexer currentTextContext.
+
+    self error: err
   )
 
   symIsMethod = (

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -494,7 +494,7 @@ Parser = (
 
     "create empty array"
     bcGen emit: mgenc pushGlobal: arrayClassName.
-    bcGen emit: mgenc pushConstant: arraySizeLiteralIndex.
+    bcGen emit: mgenc pushConstantIdx: arraySizeLiteralIndex.
     bcGen emit: mgenc send: newMessage.
 
     i := 1.

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -716,4 +716,12 @@ Parser = (
   newWith: aString for: aFilename in: universe = (
     ^ self new initializeWith: aString for: aFilename in: universe
   )
+
+  load: aFileName in: universe = (
+    | fileContent |
+    fileContent := system loadFile: aFileName.
+    fileContent == nil ifTrue: [ ^ nil ].
+
+    ^ self new initializeWith: fileContent for: aFileName in: universe
+  )
 )

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -1,9 +1,10 @@
 Parser = (
-  | lexer sym text nextSym filename cgenc |
+  | lexer sym text nextSym filename cgenc universe |
 
-  initializeWith: aString for: aFilename in: universe = (
+  initializeWith: aString for: aFilename in: aUniverse = (
     filename := aFilename.
     lexer := Lexer new: aString.
+    universe := aUniverse.
     cgenc := ClassGenerationContext new: universe.
     self takeSymbolFromLexer.
   )
@@ -16,7 +17,7 @@ Parser = (
 
   classdef = (
     | name |
-    name := text. "TODO: set on cgenc: universe.symbolFor(text)"
+    name := universe symbolFor: text.
     self expect: #identifier.
     self expect: #equal.
 
@@ -47,20 +48,26 @@ Parser = (
     | superName |
     sym == #identifier
       ifTrue: [
-        superName := text. "TODO: universe.symbolFor text"
+        superName := universe symbolFor: text.
         self accept: #identifier ]
       ifFalse: [
-        superName := 'Object'. "TODO universe.symbolFor Object" ].
+        superName := universe symbolFor: 'Object' ].
 
     cgenc superName: superName.
 
-    superName = 'nil' ifFalse: [ "superName.getEmbeddedString = 'nil' "
-      | superClass |
-      superClass := universe loadClass: superName.
-      superClass == nil ifTrue: [
-        self error: 'Was not able to load super class: ' + superName ].
-      cgenc instanceFieldsOfSuper: superClass instanceFields.
-      cgenc classFieldsOfSuper: superClass somClass instanceFields. ]
+    superName string = 'nil' ifFalse: [
+      self initializeFromSuperClass: superName ].
+  )
+
+  initializeFromSuperClass: superName = (
+    'TODO once parser complete' println.
+    "TODO
+    | superClass |
+    superClass := universe loadClass: superName.
+    superClass == nil ifTrue: [
+      self error: 'Was not able to load super class: ' + superName ].
+    cgenc instanceFieldsOfSuper: superClass instanceFields.
+    cgenc classFieldsOfSuper: superClass somClass instanceFields."
   )
 
   fields = (
@@ -72,8 +79,267 @@ Parser = (
       self expect: #or ]
   )
 
+  method: mgenc = (
+    self pattern: mgenc.
+    self expect: #equal.
+
+    sym == #primitive
+      ifTrue: [
+        mgenc markAsPrimitive.
+        self primBlock ]
+      ifFalse: [
+        self methodBlock: mgenc ]
+  )
+
+  primBlock = (
+    self expect: #primitive
+  )
+
+  pattern: mgenc = (
+    sym == #identifier ifTrue: [
+      ^ self unaryPattern: mgenc ].
+    sym == #keyword ifTrue: [
+      ^ self keywordPattern: mgenc ].
+    self binaryPattern: mgenc
+  )
+
+  unaryPattern: mgenc = (
+    mgenc signature: self unarySelector
+  )
+
+  binaryPattern: mgenc = (
+    mgenc signature: self binarySelector.
+    mgenc addArgumentIfAbsent: self argument
+  )
+
+  keywordPattern: mgenc = (
+    | kw |
+    kw := ''.
+
+    [sym == #keyword] whileTrue: [
+      kw := kw + self keyword.
+      mgenc addArgumentIfAbsent: self argument ].
+
+    mgenc signature: (universe symbolFor: kw)
+  )
+
+  methodBlock: mgenc = (
+    self expect: #newTerm.
+
+    self blockContents: mgenc.
+
+    " if no return has been generated so far, we can be sure there was no . (dot)
+      terminating the last expression, so the last expression's value must be
+      popped off the stack and a ^self be generated "
+    mgenc isFinished ifFalse: [
+      'TODO implement bcGen' println.
+      "TODO:
+      bcGen.emitPOP(mgenc);
+      bcGen.emitPUSHARGUMENT(mgenc, (byte) 0, (byte) 0);
+      bcGen.emitRETURNLOCAL(mgenc);"
+      mgenc markAsFinished ].
+
+    self expect: #endTerm.
+  )
+
+  blockContents: mgenc = (
+    (self accept: #or) ifTrue: [
+      self locals: mgenc.
+      self expect: #or ].
+    self blockBody: mgenc sawPeriod: false
+  )
+
+  locals: mgenc = (
+    [sym == #identifier] whileTrue: [
+      mgenc addLocalIfAbsent: self variable ]
+  )
+
+  blockBody: mgenc sawPeriod: seenPeriod = (
+    (self accept: #exit) ifTrue: [
+      ^ self result: mgenc ].
+
+    sym == #endBlock ifTrue: [
+      seenPeriod ifTrue: [
+        "a POP has been generated which must be elided (blocks always
+         return the value of the last expression, regardless of
+         whether it was terminated with a . or not)"
+        mgenc removeLastBytecode ].
+      bcGen emitReturnLocal: mgenc.
+      mgenc markAsFinished.
+      ^ self ].
+
+    sym == #endTerm ifTrue: [
+      "it does not matter whether a period has been seen, as the end of
+       the method has been found (EndTerm) - so it is safe to emit a
+       'return self'"
+      'TODO implement bcGen' println.
+      "TODO: bcGen.emitPUSHARGUMENT(mgenc, (byte) 0, (byte) 0);
+      bcGen.emitRETURNLOCAL(mgenc);"
+      mgenc markAsFinished.
+      ^ self ].
+
+    self expression: mgenc.
+    (self accept: #period) ifTrue: [
+      'TODO implement bcGen' println.
+      "bcGen.emitPOP(mgenc);"
+      self blockBody: mgenc sawPeriod: true ]
+  )
+
+  unarySelector = (
+    ^ universe symbolFor: self identifier
+  )
+
+  binarySelector = (
+    | s |
+    s := text.
+
+    (self accept: #or) or: [
+    (self accept: #comma) or: [
+    (self accept: #minus) or: [
+    (self accept: #equal) or: [
+    (self accept: #operatorSequence) or: [
+    (self acceptOneOf: Parser singleOpSyms) or: [
+        self expect: #none ] ] ] ] ] ].
+
+    ^ universe symbolFor: s
+  )
+
+  variable = (
+    ^ self identifier
+  )
+
+  argument = (
+    ^ self variable
+  )
+
+  identifier = (
+    | s |
+    s := text.
+    (self accept: #primitive)
+      ifFalse: [self expect: #identifier].
+    ^ s
+  )
+
+  keyword = (
+    | s |
+    s := text.
+    self expect: #keyword.
+    ^ s
+  )
+
+  expression: mgenc = (
+    self peekForNextSymbolFromLexer.
+
+    nextSym == #assign
+      ifTrue: [self assignation: mgenc]
+      ifFalse: [self evaluation: mgenc]
+  )
+
+  evaluation: mgenc = (
+    | superSend |
+    superSend := self primary: mgenc.
+    self symInMethod ifTrue: [
+      self messages: mgenc with: superSend ]
+  )
+
+  primary: mgenc = (
+    | superSend |
+    superSend := false.
+
+    sym == #identifier ifTrue: [
+      | v |
+      v := self variable.
+      v = 'super' ifTrue: [
+        superSend := true.
+        " sends to super, but pushes self as receiver"
+        v := 'self' ].
+
+      self gen: mgenc pushVariable: v.
+      ^ superSend ].
+
+    sym == #newTerm ifTrue: [
+      self nestedTerm: mgenc.
+      ^ superSend ].
+
+    sym == #newBlock ifTrue: [
+      | bgenc blockMethod |
+      bgenc := MethodGenerationContext new: mgenc holder with: mgenc.
+      bgenc markAsBlockMethod.
+
+      self nestedBlock: bgenc.
+
+      blockMethod := bgenc assembleMethod: universe.
+      mgenc addLiteral: blockMethod.
+
+      bcGen emit: mgenc pushBlock: blockMethod.
+      ^ superSend ].
+
+    self literal: mgenc.
+    ^ superSend
+  )
+
+  literal: mgenc = (
+    sym == #pound ifTrue: [
+      self peekForNextSymbolFromLexerIfNecessary.
+      nextSym == #newTerm
+        ifTrue: [ self literalArray: mgenc ]
+        ifFalse: [ self literalSymbol: mgenc ].
+      ^ self ].
+
+    sym == #string ifTrue: [
+      self literalString: mgenc.
+      ^ self ].
+
+    self literalNumber: mgenc
+  )
+
+  literalArray: mgenc = (
+    self error: 'literalArray nyi'
+  )
+
+  literalSymbol: mgenc = (
+    self error: 'literalSymbol nyi'
+  )
+
+  literalString: mgenc = (
+    self error: 'literalString nyi'
+  )
+
+  literalNumber: mgenc = (
+    | lit |
+    sym == #minus
+      ifTrue: [lit := self negativeDecimal]
+      ifFalse: [lit := self literalDecimal: false].
+
+    mgenc addLiteralIfAbsent: lit.
+    bcGen emit: mgenc pushConstant: lit
+  )
+
+  literalDecimal: isNegative = (
+    sym == #integer
+      ifTrue: [^ self literalInteger: isNegative]
+      ifFalse: [^ self literalDouble: isNegative]
+  )
+
+  literalDouble: isNegative = (
+    | d |
+    d := Double fromString: text.
+    isNegative ifTrue: [
+      d := 0.0 - d ].
+
+    self expect: #double.
+    ^ universe newDouble: d
+  )
+
   accept: s = (
     sym == s ifTrue: [
+      self takeSymbolFromLexer.
+      ^ true ].
+    ^ false
+  )
+
+  acceptOneOf: ss = (
+    (self symIn: ss) ifTrue: [
       self takeSymbolFromLexer.
       ^ true ].
     ^ false
@@ -94,6 +360,10 @@ Parser = (
 
   symIn: ss = (
     ^ ss contains: sym
+  )
+
+  peekForNextSymbolFromLexer = (
+    nextSym := lexer peek
   )
 
   ----

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -133,7 +133,7 @@ Parser = (
       popped off the stack and a ^self be generated "
     mgenc isFinished ifFalse: [
       bcGen emitPop: mgenc.
-      bcGen emit: mgenc pushArgument: 0 in: 0.
+      bcGen emit: mgenc pushArgument: 1 in: 0.
       bcGen emitReturnLocal: mgenc.
       mgenc markAsFinished ].
 
@@ -170,7 +170,7 @@ Parser = (
       "it does not matter whether a period has been seen, as the end of
        the method has been found (EndTerm) - so it is safe to emit a
        'return self'"
-      bcGen emit: mgenc pushArgument: 0 in: 0.
+      bcGen emit: mgenc pushArgument: 1 in: 0.
       bcGen emitReturnLocal: mgenc.
       mgenc markAsFinished.
       ^ self ].

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -386,7 +386,7 @@ Parser = (
     | superSend |
     superSend := self primary: mgenc.
 
-    (sym == #identifier) ifTrue: [
+    [sym == #identifier] whileTrue: [
       self unaryMessage: mgenc with: superSend.
       superSend := false ].
 

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -162,6 +162,14 @@ Parser = (
          return the value of the last expression, regardless of
          whether it was terminated with a . or not)"
         mgenc removeLastBytecode ].
+
+      (mgenc isBlockMethod and: [ mgenc hasBytecodes not ]) ifTrue: [
+        | nilSym |
+        "if the block is empty, we need to return nil"
+        nilSym := universe symbolFor: 'nil'.
+        mgenc addLiteralIfAbsent: nilSym.
+        bcGen emit: mgenc pushGlobal: aSymbol. ].
+
       bcGen emitReturnLocal: mgenc.
       mgenc markAsFinished.
       ^ self ].

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -19,8 +19,7 @@ Parser = (
   )
 
   classdef = (
-    | name |
-    name := universe symbolFor: text.
+    cgenc name: (universe symbolFor: text).
     self expect: #identifier.
     self expect: #equal.
 
@@ -63,14 +62,12 @@ Parser = (
   )
 
   initializeFromSuperClass: superName = (
-    'TODO once parser complete' println.
-    "TODO
     | superClass |
     superClass := universe loadClass: superName.
     superClass == nil ifTrue: [
-      self error: 'Was not able to load super class: ' + superName ].
+      self error: 'Was not able to load super class: ' + superName string + ' in ' + filename ].
     cgenc instanceFieldsOfSuper: superClass instanceFields.
-    cgenc classFieldsOfSuper: superClass somClass instanceFields."
+    cgenc classFieldsOfSuper: superClass somClass instanceFields.
   )
 
   fields = (
@@ -444,7 +441,7 @@ Parser = (
 
     "if no return has been generated, we can be sure that the last expression
      in the block was not terminated by ., and can generate a return"
-    mgenc isFinished ifTrue: [
+    mgenc isFinished ifFalse: [
       bcGen emitReturnLocal: mgenc.
       mgenc markAsFinished ].
 

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -1,5 +1,5 @@
 Parser = (
-  | lexer sym text nextSym filename cgenc universe |
+  | lexer sym text nextSym filename cgenc universe bcGen |
 
   initializeWith: aString for: aFilename in: aUniverse = (
     filename := aFilename.
@@ -7,6 +7,9 @@ Parser = (
     universe := aUniverse.
     cgenc := ClassGenerationContext new: universe.
     self takeSymbolFromLexer.
+
+    "This is just a convenient abbreviation."
+    bcGen := BytecodeGenerator.
   )
 
   takeSymbolFromLexer = (
@@ -132,11 +135,9 @@ Parser = (
       terminating the last expression, so the last expression's value must be
       popped off the stack and a ^self be generated "
     mgenc isFinished ifFalse: [
-      'TODO implement bcGen' println.
-      "TODO:
-      bcGen.emitPOP(mgenc);
-      bcGen.emitPUSHARGUMENT(mgenc, (byte) 0, (byte) 0);
-      bcGen.emitRETURNLOCAL(mgenc);"
+      bcGen emitPop: mgenc.
+      bcGen emit: mgenc pushArgument: 0 in: 0.
+      bcGen emitReturnLocal: mgenc.
       mgenc markAsFinished ].
 
     self expect: #endTerm.
@@ -172,16 +173,14 @@ Parser = (
       "it does not matter whether a period has been seen, as the end of
        the method has been found (EndTerm) - so it is safe to emit a
        'return self'"
-      'TODO implement bcGen' println.
-      "TODO: bcGen.emitPUSHARGUMENT(mgenc, (byte) 0, (byte) 0);
-      bcGen.emitRETURNLOCAL(mgenc);"
+      bcGen emit: mgenc pushArgument: 0 in: 0.
+      bcGen emitReturnLocal: mgenc.
       mgenc markAsFinished.
       ^ self ].
 
     self expression: mgenc.
     (self accept: #period) ifTrue: [
-      'TODO implement bcGen' println.
-      "bcGen.emitPOP(mgenc);"
+      bcGen emitPop: mgenc.
       self blockBody: mgenc sawPeriod: true ]
   )
 
@@ -227,6 +226,40 @@ Parser = (
     ^ s
   )
 
+  string = (
+    | s |
+    s := text.
+    self expect: #string.
+    ^ s
+  )
+
+  selector = (
+    (sym == #operatorSequence or: [self symIn: Parser singleOpSyms])
+      ifTrue: [^ self binarySelector].
+    (sym == #keyword or: [sym == #keywordSequence])
+      ifTrue: [^ self keywordSelector].
+
+    ^ self unarySelector
+  )
+
+  keywordSelector = (
+    | s |
+    s := text.
+    self expectOneOf: Parser keywordSelectorSyms.
+    ^ universe symbolFor: s
+  )
+
+  result: mgenc = (
+    self expression: mgenc.
+
+    mgenc isBlockMethod
+      ifTrue: [bcGen emitReturnNonLocal: mgenc ]
+      ifFalse: [bcGen emitReturnLocal: mgenc ].
+    mgenc markAsFinished.
+
+    self accept: #period
+  )
+
   expression: mgenc = (
     self peekForNextSymbolFromLexer.
 
@@ -235,10 +268,36 @@ Parser = (
       ifFalse: [self evaluation: mgenc]
   )
 
+  assignation: mgenc = (
+    | variables |
+    variables := Vector new.
+
+    self assignments: mgenc to: variables.
+    self evaluation: mgenc.
+
+    variables do: [:v | bcGen emitDup: mgenc ].
+    variables do: [:v | self gen: mgenc popVariable: v ]
+  )
+
+  assignments: mgenc to: variables = (
+    sym == #identifier ifTrue: [
+      variables append: (self assignment: mgenc).
+      self peekForNextSymbolFromLexer.
+      nextSym == #assign ifTrue: [
+        self assignments: mgenc to: variables ] ]
+  )
+
+  assignment: mgenc = (
+    | v |
+    v := self variable.
+    self expect: #assign.
+    ^ v
+  )
+
   evaluation: mgenc = (
     | superSend |
     superSend := self primary: mgenc.
-    self symInMethod ifTrue: [
+    self symIsMethod ifTrue: [
       self messages: mgenc with: superSend ]
   )
 
@@ -269,13 +328,141 @@ Parser = (
       self nestedBlock: bgenc.
 
       blockMethod := bgenc assembleMethod: universe.
-      mgenc addLiteral: blockMethod.
-
       bcGen emit: mgenc pushBlock: blockMethod.
       ^ superSend ].
 
     self literal: mgenc.
     ^ superSend
+  )
+
+  messages: mgenc with: superSend = (
+    sym == #identifier ifTrue: [
+      "only the first message in a sequence can be a super send"
+      self unaryMessage: mgenc with: superSend.
+
+      [sym == #identifier] whileTrue: [
+        self unaryMessage: mgenc with: false ].
+
+      [sym == #operatorSequence or: [self symIn: Parser binaryOpSyms]] whileTrue: [
+        self binaryMessage: mgenc with: false ].
+
+      sym == #keyword ifTrue: [
+        self keywordMessage: mgenc with: false ].
+
+      ^ self ].
+
+    (sym == #operatorSequence or: [self symIn: Parser binaryOpSyms]) ifTrue: [
+      self binaryMessage: mgenc with: superSend.
+
+      [sym == #operatorSequence or: [self symIn: Parser binaryOpSyms]] whileTrue: [
+        self binaryMessage: mgenc with: false ].
+
+      sym == #keyword ifTrue: [
+        self keywordMessage: mgenc with: false ].
+
+      ^ self ].
+
+    self keywordMessage: mgenc with: superSend
+  )
+
+  unaryMessage: mgenc with: superSend = (
+    | msg |
+    msg := self unarySelector.
+
+    superSend ifTrue: [ bcGen emit: mgenc superSend: msg ]
+              ifFalse: [ bcGen emit: mgenc send: msg ]
+  )
+
+  binaryMessage: mgenc with: superSend = (
+    | msg |
+    msg := self binarySelector.
+    self binaryOperand: mgenc.
+
+    superSend ifTrue: [ bcGen emit: mgenc superSend: msg ]
+              ifFalse: [ bcGen emit: mgenc send: msg ]
+  )
+
+  binaryOperand: mgenc = (
+    | superSend |
+    superSend := self primary: mgenc.
+
+    (sym == #identifier) ifTrue: [
+      self unaryMessage: mgenc with: superSend.
+      superSend := false ].
+
+    ^ superSend
+  )
+
+  keywordMessage: mgenc with: superSend = (
+    | kw msg |
+    kw := self keyword.
+    self formula: mgenc.
+
+    [sym == #keyword] whileTrue: [
+      kw := kw + self keyword.
+      self formula: mgenc ].
+
+    msg := universe symbolFor: kw.
+    superSend ifTrue: [ bcGen emit: mgenc superSend: msg ]
+              ifFalse: [ bcGen emit: mgenc send: msg ]
+  )
+
+  formula: mgenc = (
+    | superSend |
+    superSend := self binaryOperand: mgenc.
+
+    "only the first message in a sequence can be a super send"
+    [sym == #operatorSequence or: [self symIn: Parser binaryOpSyms]] whileTrue: [
+        self binaryMessage: mgenc with: superSend.
+        superSend := false ].
+  )
+
+  nestedTerm: mgenc = (
+    self expect: #newTerm.
+    self expression: mgenc.
+    self expect: #endTerm.
+  )
+
+  nestedBlock: mgenc = (
+    | blockSig argSize |
+    mgenc addArgumentIfAbsent: '$block self'.
+
+    self expect: #newBlock.
+
+    sym == #colon ifTrue: [
+      self blockPattern: mgenc ].
+
+    "generate block signature"
+    blockSig := '$block method'.
+    argSize := mgenc numberOfArguments.
+    (argSize - 1) timesRepeat: [
+      blockSig := blockSig + ':' ].
+
+    mgenc signature: (universe symbolFor: blockSig).
+
+    self blockContents: mgenc.
+
+    "if no return has been generated, we can be sure that the last expression
+     in the block was not terminated by ., and can generate a return"
+    mgenc isFinished ifTrue: [
+      bcGen emitReturnLocal: mgenc.
+      mgenc markAsFinished ].
+
+    self expect: #endBlock
+  )
+
+  blockPattern: mgenc = (
+    self blockArguments: mgenc.
+    self expect: #or.
+  )
+
+  blockArguments: mgenc = (
+    self expect: #colon.
+    mgenc addArgumentIfAbsent: self argument.
+
+    [sym == #colon] whileTrue: [
+      self expect: #colon.
+      mgenc addArgumentIfAbsent: self argument ]
   )
 
   literal: mgenc = (
@@ -294,15 +481,58 @@ Parser = (
   )
 
   literalArray: mgenc = (
-    self error: 'literalArray nyi'
+    | arrayClassName arraySizePlaceholder
+      newMessage atPutMessage arraySizeLiteralIndex i |
+    self expect: #pound.
+    self expect: #newTerm.
+
+    arrayClassName := universe symbolFor: 'Array'.
+    arraySizePlaceholder := universe symbolFor: 'ArraySizeLiteralPlaceholder'.
+    newMessage := universe symbolFor: 'new:'.
+    atPutMessage := universe symbolFor: 'at:put:'.
+
+    "need the array size at a know idx so that we don't need a second pass
+     over the array elements"
+    arraySizeLiteralIndex := mgenc addLiteral: arraySizePlaceholder.
+
+    "create empty array"
+    bcGen emit: mgenc pushGlobal: arrayClassName.
+    bcGen emit: mgenc pushConstant: arraySizeLiteralIndex.
+    bcGen emit: mgenc send: newMessage.
+
+    i := 1.
+
+    [sym == #endTerm] whileFalse: [
+      | pushIndex |
+      pushIndex := universe newInteger: i.
+      bcGen emit: mgenc pushConstant: pushIndex.
+      self literal: mgenc.
+      bcGen emit: mgenc send: atPutMessage.
+      i := i + 1 ].
+
+    "replace the placeholder with the actual array size"
+    mgenc updateLiteral: arraySizePlaceholder at: arraySizeLiteralIndex put: (universe newInteger: i - 1).
+    self expect: #endTerm.
   )
 
   literalSymbol: mgenc = (
-    self error: 'literalSymbol nyi'
+    | symb |
+    self expect: #pound.
+    sym == #string
+      ifTrue: [
+        | s |
+        s := self string.
+        symb := universe symbolFor: s ]
+      ifFalse: [
+        symb := self selector ].
+    bcGen emit: mgenc pushConstant: symb
   )
 
   literalString: mgenc = (
-    self error: 'literalString nyi'
+    | s str |
+    s := self string.
+    str := universe newString: s.
+    bcGen emit: mgenc pushConstant: str
   )
 
   literalNumber: mgenc = (
@@ -311,8 +541,12 @@ Parser = (
       ifTrue: [lit := self negativeDecimal]
       ifFalse: [lit := self literalDecimal: false].
 
-    mgenc addLiteralIfAbsent: lit.
     bcGen emit: mgenc pushConstant: lit
+  )
+
+  negativeDecimal = (
+    self expect: #minus.
+    ^ self literalDecimal: true
   )
 
   literalDecimal: isNegative = (
@@ -321,11 +555,21 @@ Parser = (
       ifFalse: [^ self literalDouble: isNegative]
   )
 
+  literalInteger: isNegative = (
+    | i |
+    i := Integer fromString: text.
+    isNegative ifTrue: [
+      i := i negated].
+
+    self expect: #integer.
+    ^ universe newInteger: i
+  )
+
   literalDouble: isNegative = (
     | d |
     d := Double fromString: text.
     isNegative ifTrue: [
-      d := 0.0 - d ].
+      d := d negated ].
 
     self expect: #double.
     ^ universe newDouble: d
@@ -362,9 +606,74 @@ Parser = (
     ^ ss contains: sym
   )
 
+  symIsMethod = (
+    sym == #identifier       ifTrue: [^ true].
+    sym == #keyword          ifTrue: [^ true].
+    sym == #operatorSequence ifTrue: [^ true].
+    (self symIn: Parser binaryOpSyms) ifTrue: [^ true].
+    ^ false
+  )
+
   peekForNextSymbolFromLexer = (
     nextSym := lexer peek
   )
+
+  peekForNextSymbolFromLexerIfNecessary = (
+    lexer isPeekDone ifFalse: [
+      self peekForNextSymbolFromLexer ]
+  )
+
+  gen: mgenc popVariable: var = (
+    | searchResult |
+    "Needs to determine whether the variable that is to be popped off the stack
+     is a local variable, argument, or object field.
+     This is done by examining all available lexical contexts, starting with
+     the innermost (i.e., the one represented by mgenc)."
+
+    "index, context, isArgument"
+    searchResult := Array with: 0 with: 0 with: false. "TODO support: #(0 0 false)"
+
+    (mgenc findVar: var with: searchResult)
+      ifTrue: [
+        (searchResult at: 3) "isArgument"
+          ifTrue: [bcGen emit: mgenc popArgument: (searchResult at: 1) in: (searchResult at: 2)]
+          ifFalse: [bcGen emit: mgenc popLocal: (searchResult at: 1) in: (searchResult at: 2)]
+      ]
+      ifFalse: [
+        | varSym |
+        varSym := universe symbolFor: var.
+        (mgenc hasField: varSym) ifFalse: [
+          ^ self error: 'Write to variable with the name ' + var + ', but there is no variable or field defined with this name' ].
+        bcGen emit: mgenc popField: varSym ].
+  )
+
+  gen: mgenc pushVariable: var = (
+    "Needs to determine whether the variable to be pushed on the stack
+     is a local variable, argument, or object field.
+     This is done by examining all available lexical contexts, starting with
+     the innermost (i.e., the one represented by mgenc)."
+
+    "index, context, isArgument"
+    | searchResult |
+    searchResult := Array with: 0 with: 0 with: false. "TODO support: #(0 0 false)"
+
+    (mgenc findVar: var with: searchResult)
+      ifTrue: [
+        (searchResult at: 3) "isArgument"
+          ifTrue: [
+            bcGen emit: mgenc pushArgument: (searchResult at: 1) in: (searchResult at: 2) ]
+          ifFalse: [
+            bcGen emit: mgenc pushLocal: (searchResult at: 1) in: (searchResult at: 2) ] ]
+      ifFalse: [
+        | varSym |
+        varSym := universe symbolFor: var.
+        (mgenc hasField: varSym)
+          ifTrue: [
+            bcGen emit: mgenc pushField: varSym ]
+          ifFalse: [
+            bcGen emit: mgenc pushGlobal: varSym ] ]
+  )
+
 
   ----
   | singleOpSyms binaryOpSyms keywordSelectorSyms |

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -1,0 +1,126 @@
+Parser = (
+  | lexer sym text nextSym filename cgenc |
+
+  initializeWith: aString for: aFilename in: universe = (
+    filename := aFilename.
+    lexer := Lexer new: aString.
+    cgenc := ClassGenerationContext new: universe.
+    self takeSymbolFromLexer.
+  )
+
+  takeSymbolFromLexer = (
+    sym := lexer sym.
+    text := lexer text.
+    nextSym := #none.
+  )
+
+  classdef = (
+    | name |
+    name := text. "TODO: set on cgenc: universe.symbolFor(text)"
+    self expect: #identifier.
+    self expect: #equal.
+
+    self superclass.
+
+    self expect: #newTerm.
+    self classBody.
+
+    (self accept: #separator) ifTrue: [
+      cgenc startClassSide.
+      self classBody ].
+
+    self expect: #endTerm.
+    ^ cgenc
+  )
+
+  classBody = (
+    self fields.
+    [self symIsMethod] whileTrue: [
+       | mgenc |
+       mgenc := MethodGenerationContext new: cgenc.
+       mgenc addArgument: 'self'.
+       self method: mgenc.
+       cgenc addMethod: (mgenc assemble: universe) ].
+  )
+
+  superclass = (
+    | superName |
+    sym == #identifier
+      ifTrue: [
+        superName := text. "TODO: universe.symbolFor text"
+        self accept: #identifier ]
+      ifFalse: [
+        superName := 'Object'. "TODO universe.symbolFor Object" ].
+
+    cgenc superName: superName.
+
+    superName = 'nil' ifFalse: [ "superName.getEmbeddedString = 'nil' "
+      | superClass |
+      superClass := universe loadClass: superName.
+      superClass == nil ifTrue: [
+        self error: 'Was not able to load super class: ' + superName ].
+      cgenc instanceFieldsOfSuper: superClass instanceFields.
+      cgenc classFieldsOfSuper: superClass somClass instanceFields. ]
+  )
+
+  fields = (
+    (self accept: #or) ifTrue: [
+      [sym == #identifier] whileTrue: [
+        | var |
+        var := self variable.
+        cgenc addField: (universe symbolFor: var) ].
+      self expect: #or ]
+  )
+
+  accept: s = (
+    sym == s ifTrue: [
+      self takeSymbolFromLexer.
+      ^ true ].
+    ^ false
+  )
+
+  expect: s = (
+    (self accept: s) ifTrue: [ ^ true ].
+
+    self error: 'Parsing failed, expected ' + s + ' but found ' + sym + ' (' + text + ')'
+  )
+
+  symIsMethod = (
+    ^ sym = #identifier or: [
+      sym = #keyword or: [
+      sym = #operatorSequence or: [
+      self symIn: Parser binaryOpSyms ] ] ]
+  )
+
+  symIn: ss = (
+    ^ ss contains: sym
+  )
+
+  ----
+  | singleOpSyms binaryOpSyms keywordSelectorSyms |
+
+  singleOpSyms = (
+    singleOpSyms == nil ifTrue: [
+      singleOpSyms := #(#not #and #or #star #div #mod #plus #equal
+                        #more #less #comma #at #per #none) ].
+    ^ singleOpSyms
+  )
+
+  binaryOpSyms = (
+    binaryOpSyms == nil ifTrue: [
+      binaryOpSyms := #(#or #comma #minus #equal #not #and #or #star
+                        #div #mod #plus #equal #more #less #comma #at
+                        #per #none) ].
+    ^ binaryOpSyms
+  )
+
+  keywordSelectorSyms = (
+    keywordSelectorSyms == nil ifTrue: [
+      keywordSelectorSyms := #(#keyword #keywordSequence) ].
+    ^ keywordSelectorSyms
+  )
+
+  newWith: aString for: aFilename in: universe = (
+    ^ self new initializeWith: aString for: aFilename in: universe
+  )
+)

--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -167,8 +167,7 @@ Parser = (
         | nilSym |
         "if the block is empty, we need to return nil"
         nilSym := universe symbolFor: 'nil'.
-        mgenc addLiteralIfAbsent: nilSym.
-        bcGen emit: mgenc pushGlobal: aSymbol. ].
+        bcGen emit: mgenc pushGlobal: nilSym. ].
 
       bcGen emitReturnLocal: mgenc.
       mgenc markAsFinished.

--- a/SomSom/src/compiler/SourcecodeCompiler.som
+++ b/SomSom/src/compiler/SourcecodeCompiler.som
@@ -1,0 +1,34 @@
+SourcecodeCompiler = (
+  ----
+  compileClass: path name: fileName into: systemClass in: universe = (
+    | fname parser result cname |
+    fname := path + '/' + fileName + '.som'.
+
+    parser := Parser load: fname in: universe.
+    parser ifNil: [ ^ nil ].
+
+    result := self compile: parser into: systemClass.
+
+    cname := result name string.
+
+    fileName ~= cname ifTrue: [
+      self error: 'File name ' + fname
+          + ' does not match class name (' + cname + ') in it.' ].
+    ^ result
+  )
+
+  compileClass: stmt into: systemClass in: universe = (
+    | parser |
+    parser := Parser newWith: stmt for: '$string$' in: universe.
+    ^ self compile: parser into: systemClass.
+  )
+
+  compile: parser into: systemClass = (
+    | cgc |
+    cgc := parser classdef.
+
+    systemClass == nil
+      ifTrue: [ ^ cgc assemble ]
+      ifFalse: [ ^ cgc assembleSystemClass: systemClass ]
+  )
+)

--- a/SomSom/src/interpreter/Bytecodes.som
+++ b/SomSom/src/interpreter/Bytecodes.som
@@ -1,0 +1,33 @@
+Bytecodes = (
+  ----
+
+  length: bytecode = (
+    bytecode == #halt           ifTrue: [ ^ 1 ].
+    bytecode == #dup            ifTrue: [ ^ 1 ].
+    bytecode == #pushLocal      ifTrue: [ ^ 3 ].
+    bytecode == #pushArgument   ifTrue: [ ^ 3 ].
+    bytecode == #pushField      ifTrue: [ ^ 2 ].
+    bytecode == #pushBlock      ifTrue: [ ^ 2 ].
+    bytecode == #pushConstant   ifTrue: [ ^ 2 ].
+    bytecode == #pushGlobal     ifTrue: [ ^ 2 ].
+    bytecode == #pop            ifTrue: [ ^ 1 ].
+    bytecode == #popLocal       ifTrue: [ ^ 3 ].
+    bytecode == #popArgument    ifTrue: [ ^ 3 ].
+    bytecode == #popField       ifTrue: [ ^ 2 ].
+    bytecode == #send           ifTrue: [ ^ 2 ].
+    bytecode == #superSend      ifTrue: [ ^ 2 ].
+    bytecode == #returnLocal    ifTrue: [ ^ 1 ].
+    bytecode == #returnNonLocal ifTrue: [ ^ 1 ].
+
+    self error: 'Unknown bytecode' + bytecode asString
+  )
+
+  paddedBytecodeName: bytecodeSymbol = (
+    | max padded |
+    max := #returnNonLocal length.
+    padded := bytecodeSymbol asString.
+    [padded length < max] whileTrue: [
+      padded := padded + ' ' ].
+    ^ padded
+  )
+)

--- a/SomSom/src/interpreter/Frame.som
+++ b/SomSom/src/interpreter/Frame.som
@@ -2,7 +2,7 @@ Frame = (
 "
 Frame layout:
 +-----------------+
-| Arguments       | 0
+| Arguments       | 1
 +-----------------+
 | Local Variables | <-- localOffset
 +-----------------+
@@ -11,7 +11,7 @@ Frame layout:
 +-----------------+
 "
 |
-  "Private variables holding the stack pointer and the bytecode index"
+  "Points at the top element"
   stackPointer
   bytecodeIndex
 
@@ -27,7 +27,11 @@ Frame layout:
     previousFrame := prevFrame.
     context := contextFrame.
     method := aSMethod.
-    stack := Array new: stackElements withAll: nilObject
+    stack := Array new: stackElements withAll: nilObject.
+
+    "Reset the stack pointer and the bytecode index"
+    self resetStackPointer.
+    bytecodeIndex := 1.
   )
 
   previousFrame = (
@@ -91,7 +95,7 @@ Frame layout:
     "Pop an object from the expression stack and return it"
     sp := stackPointer.
     stackPointer := stackPointer - 1.
-    ^ stack at: stackPointer
+    ^ stack at: sp.
   )
 
   push: aSAbstractObject = (
@@ -104,7 +108,7 @@ Frame layout:
 
   resetStackPointer = (
     "arguments are stored in front of local variables"
-    localOffset := method numberOfArguments.
+    localOffset := method numberOfArguments + 1.
 
     "Set the stack pointer to its initial value thereby clearing the stack"
     stackPointer := localOffset + method numberOfLocals - 1
@@ -133,11 +137,11 @@ Frame layout:
   )
 
   local: index = (
-    ^ stack at: localOffset + index
+    ^ stack at: localOffset + index - 1
   )
 
   local: index put: value = (
-    stack at: localOffset + index put: value
+    stack at: localOffset + index - 1 put: value
   )
 
   local: index at: contextLevel = (
@@ -182,8 +186,8 @@ Frame layout:
      - arguments are at the top of the stack of frame.
      - copy them into the argument area of the current frame"
     numArgs := method numberOfArguments.
-    1 to: numArgs do: [:i |
-      stack at: i put: (frame stackElement: numArgs - 1 - i) ]
+    0 to: numArgs - 1 do: [:i |
+      stack at: i + 1 put: (frame stackElement: numArgs - 1 - i) ]
   )
 
   printStackTrace = (

--- a/SomSom/src/interpreter/Frame.som
+++ b/SomSom/src/interpreter/Frame.som
@@ -1,0 +1,205 @@
+Frame = (
+"
+Frame layout:
++-----------------+
+| Arguments       | 0
++-----------------+
+| Local Variables | <-- localOffset
++-----------------+
+| Stack           | <-- stackPointer
+| ...             |
++-----------------+
+"
+|
+  "Private variables holding the stack pointer and the bytecode index"
+  stackPointer
+  bytecodeIndex
+
+  "the offset at which local variables start"
+  localOffset
+
+  method
+  context
+  previousFrame
+  stack
+|
+  initialize: nilObject previous: prevFrame context: contextFrame method: aSMethod maxStack: stackElements = (
+    previousFrame := prevFrame.
+    context := contextFrame.
+    method := aSMethod.
+    stack := Array new: stackElements withAll: nilObject
+  )
+
+  previousFrame = (
+    ^ previousFrame
+  )
+
+  clearPreviousFrame = (
+    previousFrame := nil
+  )
+
+  hasPreviousFrame = (
+    ^ previousFrame ~= nil
+  )
+
+  isBootstrapFrame = (
+    ^ self hasPreviousFrame not
+  )
+
+  context = (
+    ^ context
+  )
+
+  hasContext = (
+    ^ context ~= nil
+  )
+
+  context: level = (
+    | frame |
+    "Get the context frame at the given level"
+    frame := self.
+
+    "Iterate through the context chain until the given level is reached"
+    [level > 0] whileTrue: [
+      "Get the context of the current frame"
+      frame := frame context.
+
+      "Go to the next level"
+      level := level - 1 ].
+
+    ^ frame
+  )
+
+  outerContext = (
+    | frame |
+    "Compute the outer context of this frame"
+    frame := self.
+
+    "Iterate through the context chain until null is reached"
+    [frame hasContext] whileTrue: [
+      frame := frame context ].
+
+    ^ frame
+  )
+
+  method = (
+    ^ method
+  )
+
+  pop = (
+    | sp |
+    "Pop an object from the expression stack and return it"
+    sp := stackPointer.
+    stackPointer := stackPointer - 1.
+    ^ stack at: stackPointer
+  )
+
+  push: aSAbstractObject = (
+    "Push an object onto the expression stack"
+    | sp |
+    sp := stackPointer + 1.
+    stack at: sp put: aSAbstractObject.
+    stackPointer := sp
+  )
+
+  resetStackPointer = (
+    "arguments are stored in front of local variables"
+    localOffset := method numberOfArguments.
+
+    "Set the stack pointer to its initial value thereby clearing the stack"
+    stackPointer := localOffset + method numberOfLocals - 1
+  )
+
+  bytecodeIndex = (
+    "Get the current bytecode index for this frame"
+    ^ bytecodeIndex
+  )
+
+  bytecodeIndex: value = (
+    "Set the current bytecode index for this frame"
+    bytecodeIndex := value
+  )
+
+  stackElement: index = (
+    "Get the stack element with the given index
+     (an index of zero yields the top element)"
+    ^ stack at: stackPointer - index
+  )
+
+  stackElement: index put: value = (
+    "Set the stack element with the given index to the given value
+     (an index of zero yields the top element)"
+    stack at: stackPointer - index put: value
+  )
+
+  local: index = (
+    ^ stack at: localOffset + index
+  )
+
+  local: index put: value = (
+    stack at: localOffset + index put: value
+  )
+
+  local: index at: contextLevel = (
+    "Get the local with the given index in the given context"
+    ^ (self context: contextLevel) local: index
+  )
+
+  local: index at: contextLevel put: value = (
+    "Set the local with the given index in the given context to the given value"
+    (self context: contextLevel) local: index put: value
+  )
+
+  argument: index = (
+    ^ stack at: index
+  )
+
+  argument: index put: value = (
+    ^ stack at: index put: value
+  )
+
+  argument: index at: contextLevel = (
+    | context |
+    "Get the context"
+    context := self context: contextLevel.
+
+    "Get the argument with the given index"
+    ^ context argument: index
+  )
+
+  argument: index at: contextLevel put: value = (
+    | context |
+    "Get the context"
+    context := self context: contextLevel.
+
+    "Set the argument with the given index to the given value"
+    context argument: index put: value
+  )
+
+  copyArgumentsFrom: frame = (
+    | numArgs |
+    "copy arguments from frame:
+     - arguments are at the top of the stack of frame.
+     - copy them into the argument area of the current frame"
+    numArgs := method numberOfArguments.
+    1 to: numArgs do: [:i |
+      stack at: i put: (frame stackElement: numArgs - 1 - i) ]
+  )
+
+  printStackTrace = (
+    | className methodName |
+    "Print a stack trace starting in this frame"
+    self hasPreviousFrame ifTrue: [
+      previousFrame printStackTrace ].
+
+    className := method holder name string.
+    methodName := method signature string.
+    Universe println: className + '>>#' + methodName + ' @bi: ' + bytecodeIndex
+  )
+
+  ----
+
+  new: nilObject previous: prevFrame context: contextFrame method: aSMethod maxStack: stackElements = (
+    ^ self new initialize: nilObject previous: prevFrame context: contextFrame method: aSMethod maxStack: stackElements
+  )
+)

--- a/SomSom/src/interpreter/Interpreter.som
+++ b/SomSom/src/interpreter/Interpreter.som
@@ -102,7 +102,7 @@ Interpreter = (
     invokable ~= nil
       ifTrue: [
         "Invoke the invokable in the current frame"
-        invokable invoke: frame with: this ]
+        invokable invoke: frame using: this ]
       ifFalse: [
         | numberOfArguments receiver |
         numberOfArguments := signature numberOfSignatureArguments.
@@ -170,7 +170,7 @@ Interpreter = (
 
   dispatch: bytecode idx: bytecodeIndex = (
     bytecode == #halt ifTrue: [
-      ^ frame stackElement: 1 ].
+      ^ frame stackElement: 0 ].
 
     bytecode == #dup ifTrue: [
       self doDup.
@@ -225,11 +225,11 @@ Interpreter = (
       ^ nil ].
 
     bytecode == #returnLocal ifTrue: [
-      self doReturnLocal: bytecodeIndex.
+      self doReturnLocal.
       ^ nil ].
 
     bytecode == #returnNonLocal ifTrue: [
-      self doReturnNonLocal: bytecodeIndex.
+      self doReturnNonLocal.
       ^ nil ].
 
     self error: 'Unknown bytecode' + bytecode asString
@@ -242,6 +242,63 @@ Interpreter = (
 
   pushNewFrame: method = (
     ^ self pushNewFrame: method with: nil
+  )
+
+  frame = (
+    ^ frame
+  )
+
+  method = (
+    ^ frame method
+  )
+
+  getSelf = (
+    "Get the self object from the interpreter"
+    ^ frame outerContext argument: 1 at: 1
+  )
+
+  send: selector rcvrClass: receiverClass bc: bytecodeIndex = (
+    | invokable |
+    invokable := receiverClass lookupInvokable: selector.
+    invokable ~= nil
+      ifTrue: [
+        "Invoke the invokable in the current frame"
+        invokable invoke: frame using: self ]
+      ifFalse: [
+        | numberOfArguments receiver |
+        numberOfArguments := selector numberOfSignatureArguments.
+
+        "Compute the receiver"
+        receiver := frame stackElement: numberOfArguments - 1.
+        receiver sendDoesNotUnderstand: selector in: universe with: self ]
+  )
+
+  popFrame = (
+    | result |
+    "Save a reference to the top frame"
+    result := frame.
+
+    "Pop the top frame from the frame stack"
+    frame := frame previousFrame.
+
+    "Destroy the previous pointer on the old top frame"
+    result clearPreviousFrame.
+
+    "Return the popped frame"
+    ^ result
+  )
+
+  popFrameAndPushResult: result = (
+    | numberOfArguments |
+    "Pop the top frame from the interpreter frame stack and
+     get the number of arguments"
+    numberOfArguments := self popFrame method numberOfArguments.
+
+    "Pop the arguments"
+    numberOfArguments
+      timesRepeat: [ frame pop ].
+
+    frame push: result
   )
 
   ----

--- a/SomSom/src/interpreter/Interpreter.som
+++ b/SomSom/src/interpreter/Interpreter.som
@@ -55,7 +55,7 @@ Interpreter = (
       ifTrue: [ frame push: global  ]
       ifFalse: [
         "Send 'unknownGlobal:' to self"
-        self getSelf sendUnknownGlobal: globalName in: universe with: this ]
+        self getSelf sendUnknownGlobal: globalName in: universe using: self ]
   )
 
   doPop = (
@@ -102,12 +102,12 @@ Interpreter = (
     invokable ~= nil
       ifTrue: [
         "Invoke the invokable in the current frame"
-        invokable invoke: frame using: this ]
+        invokable invoke: frame using: self ]
       ifFalse: [
         | numberOfArguments receiver |
         numberOfArguments := signature numberOfSignatureArguments.
         receiver := frame stackElement: numberOfArguments - 1.
-        receiver sendDoesNotUnderstand: signature in: universe with: this ]
+        receiver sendDoesNotUnderstand: signature in: universe using: self ]
   )
 
   doReturnLocal = (
@@ -144,7 +144,7 @@ Interpreter = (
       numArgs timesRepeat: [ frame pop ].
 
       "... and execute the escapedBlock message instead"
-      sender sendEscapedBlock: block in: universe with: this.
+      sender sendEscapedBlock: block in: universe using: self.
       ^ self ].
 
     "Unwind the frames"
@@ -270,7 +270,7 @@ Interpreter = (
 
         "Compute the receiver"
         receiver := frame stackElement: numberOfArguments - 1.
-        receiver sendDoesNotUnderstand: selector in: universe with: self ]
+        receiver sendDoesNotUnderstand: selector in: universe using: self ]
   )
 
   popFrame = (

--- a/SomSom/src/interpreter/Interpreter.som
+++ b/SomSom/src/interpreter/Interpreter.som
@@ -6,7 +6,7 @@ Interpreter = (
   )
 
   doDup = (
-    frame push: (frame stackElement: 1)
+    frame push: (frame stackElement: 0)
   )
 
   doPushLocal: bytecodeIndex = (
@@ -126,14 +126,14 @@ Interpreter = (
     context := frame outerContext.
 
     "Make sure the block context is still on the stack"
-    context hasPreviousFrame not ifTrue: [
+    context hasPreviousFrame ifFalse: [
       | block sender method numArgs |
       "Try to recover by sending 'escapedBlock:' to the sending object
        this can get a bit nasty when using nested blocks. In this case
        the 'sender' will be the surrounding block and not the object
        that actually sent the 'value' message."
-      block := frame argument: 1 at: 1.
-      sender := frame previousFrame outerContext argument: 1 at: 1.
+      block := frame argument: 1 at: 0.
+      sender := frame previousFrame outerContext argument: 1 at: 0.
 
       "pop the frame of the currently executing block..."
       self popFrame.
@@ -254,7 +254,7 @@ Interpreter = (
 
   getSelf = (
     "Get the self object from the interpreter"
-    ^ frame outerContext argument: 1 at: 1
+    ^ frame outerContext argument: 1 at: 0
   )
 
   send: selector rcvrClass: receiverClass bc: bytecodeIndex = (

--- a/SomSom/src/interpreter/Interpreter.som
+++ b/SomSom/src/interpreter/Interpreter.som
@@ -5,6 +5,236 @@ Interpreter = (
     universe := aUniverse
   )
 
+  doDup = (
+    frame push: (frame stackElement: 1)
+  )
+
+  doPushLocal: bytecodeIndex = (
+    frame push: (
+        frame local: (frame method bytecode: bytecodeIndex + 1)
+                 at: (frame method bytecode: bytecodeIndex + 2))
+  )
+
+  doPushArgument: bytecodeIndex = (
+    frame push: (
+        frame argument: (frame method bytecode: bytecodeIndex + 1)
+                    at: (frame method bytecode: bytecodeIndex + 2))
+  )
+
+  doPushField: bytecodeIndex = (
+    | fieldIndex |
+    fieldIndex := frame method bytecode: bytecodeIndex + 1.
+
+    "Push the field with the computed index onto the stack"
+    frame push: (self getSelf field: fieldIndex)
+  )
+
+  doPushBlock: bytecodeIndex = (
+    | blockMethod |
+    blockMethod := frame method constant: bytecodeIndex.
+
+    "Push a new block with the current frame as context onto the stack"
+    frame push: (
+        universe newBlock: blockMethod
+                     with: frame
+                  numArgs: blockMethod numberOfArguments)
+  )
+
+  doPushConstant: bytecodeIndex = (
+    frame push: (frame method constant: bytecodeIndex)
+  )
+
+  doPushGlobal: bytecodeIndex = (
+    | globalName global |
+    globalName := frame method constant: bytecodeIndex.
+
+    "Get the global from the universe"
+    global := universe global: globalName.
+
+    global ~= nil
+      ifTrue: [ frame push: global  ]
+      ifFalse: [
+        "Send 'unknownGlobal:' to self"
+        self getSelf sendUnknownGlobal: globalName in: universe with: this ]
+  )
+
+  doPop = (
+    frame pop
+  )
+
+  doPopLocal: bytecodeIndex = (
+    frame local: (frame method bytecode: bytecodeIndex + 1)
+             at: (frame method bytecode: bytecodeIndex + 2)
+            put: frame pop
+  )
+
+  doPopArgument: bytecodeIndex = (
+    frame argument: (frame method bytecode: bytecodeIndex + 1)
+                at: (frame method bytecode: bytecodeIndex + 2)
+               put: frame pop
+  )
+
+  doPopField: bytecodeIndex = (
+    | fieldIndex |
+    fieldIndex := frame method bytecode: bytecodeIndex + 1.
+
+    "Set the field with the computed index to the value popped from the stack"
+    self getSelf field: fieldIndex put: frame pop
+  )
+
+  doSend: bytecodeIndex = (
+    | signature numberOfArguments receiver |
+    signature := frame method constant: bytecodeIndex.
+    numberOfArguments := signature numberOfSignatureArguments.
+    receiver := frame stackElement: numberOfArguments - 1.
+    self send: signature rcvrClass: (receiver somClassIn: universe) bc: bytecodeIndex
+  )
+
+  doSuperSend: bytecodeIndex = (
+    | signature holderSuper invokable |
+    signature := frame method constant: bytecodeIndex.
+
+    "Send the message
+     Lookup the invokable with the given signature"
+    holderSuper := frame method holder superClass.
+    invokable := holderSuper lookupInvokable: signature.
+
+    invokable ~= nil
+      ifTrue: [
+        "Invoke the invokable in the current frame"
+        invokable invoke: frame with: this ]
+      ifFalse: [
+        | numberOfArguments receiver |
+        numberOfArguments := signature numberOfSignatureArguments.
+        receiver := frame stackElement: numberOfArguments - 1.
+        receiver sendDoesNotUnderstand: signature in: universe with: this ]
+  )
+
+  doReturnLocal = (
+    | result |
+    result := frame pop.
+
+    "Pop the top frame and push the result"
+    self popFrameAndPushResult: result
+  )
+
+  doReturnNonLocal = (
+    | result context |
+    result := frame pop.
+
+    "Compute the context for the non-local return"
+    context := frame outerContext.
+
+    "Make sure the block context is still on the stack"
+    context hasPreviousFrame not ifTrue: [
+      | block sender method numArgs |
+      "Try to recover by sending 'escapedBlock:' to the sending object
+       this can get a bit nasty when using nested blocks. In this case
+       the 'sender' will be the surrounding block and not the object
+       that actually sent the 'value' message."
+      block := frame argument: 1 at: 1.
+      sender := frame previousFrame outerContext argument: 1 at: 1.
+
+      "pop the frame of the currently executing block..."
+      self popFrame.
+
+      "pop old arguments from stack"
+      method := frame method.
+      numArgs := method numberOfArguments.
+      numArgs timesRepeat: [ frame pop ].
+
+      "... and execute the escapedBlock message instead"
+      sender sendEscapedBlock: block in: universe with: this.
+      ^ self ].
+
+    "Unwind the frames"
+    [frame ~= context] whileTrue: [
+      self popFrame ].
+
+    self popFrameAndPushResult: result
+  )
+
+  start = (
+    [true] whileTrue: [
+      | bytecodeIndex bytecode bytecodeLength nextBytecodeIndex result |
+      bytecodeIndex := frame bytecodeIndex.
+      bytecode := frame method bytecode: bytecodeIndex.
+      bytecodeLength := Bytecodes length: bytecode.
+      nextBytecodeIndex := bytecodeIndex + bytecodeLength.
+      frame bytecodeIndex: nextBytecodeIndex.
+
+      result := self dispatch: bytecode idx: bytecodeIndex.
+      result ~= nil
+        ifTrue: [ ^ result ] ]
+  )
+
+  dispatch: bytecode idx: bytecodeIndex = (
+    bytecode == #halt ifTrue: [
+      ^ frame stackElement: 1 ].
+
+    bytecode == #dup ifTrue: [
+      self doDup.
+      ^ nil ].
+
+    bytecode == #pushLocal ifTrue: [
+      self doPushLocal: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #pushArgument ifTrue: [
+      self doPushArgument: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #pushField ifTrue: [
+      self doPushField: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #pushBlock ifTrue: [
+      self doPushBlock: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #pushConstant ifTrue: [
+      self doPushConstant: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #pushGlobal ifTrue: [
+      self doPushGlobal: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #pop ifTrue: [
+      self doPop.
+      ^ nil ].
+
+    bytecode == #popLocal ifTrue: [
+      self doPopLocal: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #popArgument ifTrue: [
+      self doPopArgument: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #popField ifTrue: [
+      self doPopField: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #send ifTrue: [
+      self doSend: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #superSend ifTrue: [
+      self doSuperSend: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #returnLocal ifTrue: [
+      self doReturnLocal: bytecodeIndex.
+      ^ nil ].
+
+    bytecode == #returnNonLocal ifTrue: [
+      self doReturnNonLocal: bytecodeIndex.
+      ^ nil ].
+
+    self error: 'Unknown bytecode' + bytecode asString
+  )
+
   pushNewFrame: method with: contextFrame = (
     frame := universe newFrame: frame with: method with: contextFrame.
     ^ frame

--- a/SomSom/src/interpreter/Interpreter.som
+++ b/SomSom/src/interpreter/Interpreter.som
@@ -1,0 +1,13 @@
+Interpreter = (
+  | universe |
+
+  initializeWith: aUniverse = (
+    universe := aUniverse
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initializeWith: universe
+  )
+)

--- a/SomSom/src/interpreter/Interpreter.som
+++ b/SomSom/src/interpreter/Interpreter.som
@@ -1,8 +1,17 @@
 Interpreter = (
-  | universe |
+  | universe frame |
 
   initializeWith: aUniverse = (
     universe := aUniverse
+  )
+
+  pushNewFrame: method with: contextFrame = (
+    frame := universe newFrame: frame with: method with: contextFrame.
+    ^ frame
+  )
+
+  pushNewFrame: method = (
+    ^ self pushNewFrame: method with: nil
   )
 
   ----

--- a/SomSom/src/interpreter/Interpreter.som
+++ b/SomSom/src/interpreter/Interpreter.som
@@ -87,7 +87,7 @@ Interpreter = (
     signature := frame method constant: bytecodeIndex.
     numberOfArguments := signature numberOfSignatureArguments.
     receiver := frame stackElement: numberOfArguments - 1.
-    self send: signature rcvrClass: (receiver somClassIn: universe) bc: bytecodeIndex
+    self send: signature rcvrClass: (receiver somClassIn: universe)
   )
 
   doSuperSend: bytecodeIndex = (
@@ -99,15 +99,7 @@ Interpreter = (
     holderSuper := frame method holder superClass.
     invokable := holderSuper lookupInvokable: signature.
 
-    invokable ~= nil
-      ifTrue: [
-        "Invoke the invokable in the current frame"
-        invokable invoke: frame using: self ]
-      ifFalse: [
-        | numberOfArguments receiver |
-        numberOfArguments := signature numberOfSignatureArguments.
-        receiver := frame stackElement: numberOfArguments - 1.
-        receiver sendDoesNotUnderstand: signature in: universe using: self ]
+    self activate: invokable orDnu: signature
   )
 
   doReturnLocal = (
@@ -257,20 +249,22 @@ Interpreter = (
     ^ frame outerContext argument: 1 at: 0
   )
 
-  send: selector rcvrClass: receiverClass bc: bytecodeIndex = (
+  send: selector rcvrClass: receiverClass = (
     | invokable |
     invokable := receiverClass lookupInvokable: selector.
-    invokable ~= nil
-      ifTrue: [
-        "Invoke the invokable in the current frame"
-        invokable invoke: frame using: self ]
-      ifFalse: [
-        | numberOfArguments receiver |
-        numberOfArguments := selector numberOfSignatureArguments.
+    self activate: invokable orDnu: selector
+  )
 
-        "Compute the receiver"
-        receiver := frame stackElement: numberOfArguments - 1.
-        receiver sendDoesNotUnderstand: selector in: universe using: self ]
+  activate: invokable orDnu: signature = (
+    invokable ~= nil
+        ifTrue: [
+          "Invoke the invokable in the current frame"
+          invokable invoke: frame using: self ]
+        ifFalse: [
+          | numberOfArguments receiver |
+          numberOfArguments := signature numberOfSignatureArguments.
+          receiver := frame stackElement: numberOfArguments - 1.
+          receiver sendDoesNotUnderstand: signature in: universe using: self ]
   )
 
   popFrame = (

--- a/SomSom/src/primitives/ArrayPrimitives.som
+++ b/SomSom/src/primitives/ArrayPrimitives.som
@@ -1,0 +1,17 @@
+ArrayPrimitives = Primitives (
+
+  installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'at:' in: universe with: [:frame :interp |
+        | idx |
+        idx := frame pop.
+        self := frame pop.
+        frame push: (self indexableField: index integer)])
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/ArrayPrimitives.som
+++ b/SomSom/src/primitives/ArrayPrimitives.som
@@ -3,10 +3,33 @@ ArrayPrimitives = Primitives (
   installPrimitives = (
     self installInstancePrimitive: (
       SPrimitive new: 'at:' in: universe with: [:frame :interp |
-        | idx |
+        | idx rcvr |
         idx := frame pop.
-        self := frame pop.
-        frame push: (self indexableField: index integer)])
+        rcvr := frame pop.
+        frame push: (rcvr indexableField: idx integer)]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'at:put:' in: universe with: [:frame :interp |
+        | rcvr idx value |
+        value := frame pop.
+        idx   := frame pop.
+        rcvr  := frame stackElement: 0.
+        rcvr indexableField: idx integer put: value ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'length' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+
+        frame push: (universe newInteger: rcvr numberOfIndexableFields) ]).
+
+    self installClassPrimitive: (
+      SPrimitive new: 'new:' in: universe with: [:frame :interp |
+        | arg |
+        arg := frame pop.
+        frame pop.
+
+        frame push: (universe newArray: arg integer) ]).
   )
 
   ----

--- a/SomSom/src/primitives/BlockPrimitives.som
+++ b/SomSom/src/primitives/BlockPrimitives.som
@@ -1,0 +1,12 @@
+BlockPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/BlockPrimitives.som
+++ b/SomSom/src/primitives/BlockPrimitives.som
@@ -1,7 +1,10 @@
 BlockPrimitives = Primitives (
 
   installPrimitives = (
-
+    self installInstancePrimitive: (
+      SPrimitive new: 'restart' in: universe with: [:frame :interp |
+        frame bytecodeIndex: 1.
+        frame resetStackPointer. ]).
   )
 
   ----

--- a/SomSom/src/primitives/ClassPrimitives.som
+++ b/SomSom/src/primitives/ClassPrimitives.som
@@ -1,0 +1,12 @@
+ClassPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/ClassPrimitives.som
+++ b/SomSom/src/primitives/ClassPrimitives.som
@@ -1,7 +1,35 @@
 ClassPrimitives = Primitives (
 
   installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'new' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInstance: rcvr) ]).
 
+    self installInstancePrimitive: (
+      SPrimitive new: 'name' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr name ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'superclass' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr superClass ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'fields' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr instanceFields ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'methods' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr instanceInvokables ]).
   )
 
   ----

--- a/SomSom/src/primitives/DoublePrimitives.som
+++ b/SomSom/src/primitives/DoublePrimitives.som
@@ -113,7 +113,7 @@ DoublePrimitives = Primitives (
         | rcvr arg |
         arg  := frame pop.
         rcvr := frame pop.
-        frame push: (universe newDouble: (String fromString: arg string)) ]).
+        frame push: (universe newDouble: (Double fromString: arg string)) ]).
   )
 
   ----

--- a/SomSom/src/primitives/DoublePrimitives.som
+++ b/SomSom/src/primitives/DoublePrimitives.som
@@ -1,0 +1,12 @@
+DoublePrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/DoublePrimitives.som
+++ b/SomSom/src/primitives/DoublePrimitives.som
@@ -1,7 +1,119 @@
 DoublePrimitives = Primitives (
 
-  installPrimitives = (
+  coerceToDouble: anSAbstractObject = (
+    anSAbstractObject class == SDouble ifTrue: [
+      ^ anSAbstractObject double ].
+    anSAbstractObject class == SInteger ifTrue: [
+      ^ anSAbstractObject integer asDouble ].
+    self error: 'Cannot coerce ' + anSAbstractObject debugString + ' to double'.
+  )
 
+  installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'asString' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newString: rcvr double asString) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'asInteger' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: rcvr double asInteger) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'sqrt' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double sqrt) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '+' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg  := self coerceToDouble: frame pop.
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double + arg) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '-' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg  := self coerceToDouble: frame pop.
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double - arg) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '*' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg  := self coerceToDouble: frame pop.
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double * arg) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '//' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg  := self coerceToDouble: frame pop.
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double // arg) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '%' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg  := self coerceToDouble: frame pop.
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double % arg) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '=' in: universe with: [:frame :interp |
+        | argument rcvr left |
+        argument := frame pop.
+        rcvr := frame pop.
+        left := rcvr double.
+
+        frame push: (self somBool: (
+          (argument class == SDouble)
+            ifTrue: [left = argument double]
+            ifFalse: [
+              argument class == SInteger
+                ifTrue: [left = argument integer]
+                ifFalse: [ false ] ])) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '<' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg  := self coerceToDouble: frame pop.
+        rcvr := frame pop.
+        frame push: (self somBool: rcvr double < arg) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'round' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: rcvr double round) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'sin' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double sin) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'cos' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr double cos) ]).
+
+    self installClassPrimitive: (
+      SPrimitive new: 'PositiveInfinity' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newDouble: Double PositiveInfinity) ]).
+
+    self installClassPrimitive: (
+      SPrimitive new: 'fromString:' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg  := frame pop.
+        rcvr := frame pop.
+        frame push: (universe newDouble: (String fromString: arg string)) ]).
   )
 
   ----

--- a/SomSom/src/primitives/IntegerPrimitives.som
+++ b/SomSom/src/primitives/IntegerPrimitives.som
@@ -107,15 +107,13 @@ IntegerPrimitives = Primitives (
         rcvr := frame pop.
         left := rcvr integer.
 
-        frame push: ((
+        frame push: (self somBool: (
           (argument class == SDouble)
             ifTrue: [left = argument double]
             ifFalse: [
               argument class == SInteger
                 ifTrue: [left = argument integer]
-                ifFalse: [ false ] ])
-            ifTrue: [universe trueObject]
-            ifFalse: [universe falseObject] ) ]).
+                ifFalse: [ false ] ])) ]).
 
     self installInstancePrimitive: (
       SPrimitive new: '<<' in: universe with: [:frame :interp |
@@ -131,15 +129,13 @@ IntegerPrimitives = Primitives (
         rcvr := frame pop.
         left := rcvr integer.
 
-        frame push: ((
+        frame push: (self somBool: (
           (argument class == SDouble)
             ifTrue: [left < argument double]
             ifFalse: [
               argument class == SInteger
                 ifTrue: [left < argument integer]
-                ifFalse: [ false ] ])
-            ifTrue: [universe trueObject]
-            ifFalse: [universe falseObject] ) ]).
+                ifFalse: [ false ] ])) ]).
 
     self installInstancePrimitive: (
       SPrimitive new: 'bitXor:' in: universe with: [:frame :interp |

--- a/SomSom/src/primitives/IntegerPrimitives.som
+++ b/SomSom/src/primitives/IntegerPrimitives.som
@@ -13,7 +13,7 @@ IntegerPrimitives = Primitives (
         | rcvr result |
         rcvr := frame pop.
         result := rcvr integer sqrt.
-        result class == SInteger
+        result class == Integer
           ifTrue: [frame push: (universe newInteger: result)]
           ifFalse: [frame push: (universe newDouble: result)] ]).
 

--- a/SomSom/src/primitives/IntegerPrimitives.som
+++ b/SomSom/src/primitives/IntegerPrimitives.som
@@ -24,6 +24,12 @@ IntegerPrimitives = Primitives (
         frame push: (universe newInteger: rcvr integer atRandom) ]).
 
     self installInstancePrimitive: (
+      SPrimitive new: 'asDouble' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newDouble: rcvr integer asDouble) ]).
+
+    self installInstancePrimitive: (
       SPrimitive new: '+' in: universe with: [:frame :interp |
         | argument rcvr |
         argument := frame pop.

--- a/SomSom/src/primitives/IntegerPrimitives.som
+++ b/SomSom/src/primitives/IntegerPrimitives.som
@@ -116,6 +116,18 @@ IntegerPrimitives = Primitives (
                 ifFalse: [ false ] ])) ]).
 
     self installInstancePrimitive: (
+      SPrimitive new: '==' in: universe with: [:frame :interp |
+        | argument rcvr left |
+        argument := frame pop.
+        rcvr := frame pop.
+        left := rcvr integer.
+
+        frame push: (self somBool: (
+          argument class == SInteger
+            ifTrue: [left = argument integer]
+            ifFalse: [ false ] )) ]) dontWarn: true.
+
+    self installInstancePrimitive: (
       SPrimitive new: '<<' in: universe with: [:frame :interp |
         | argument rcvr |
         argument := frame pop.

--- a/SomSom/src/primitives/IntegerPrimitives.som
+++ b/SomSom/src/primitives/IntegerPrimitives.som
@@ -1,7 +1,177 @@
 IntegerPrimitives = Primitives (
 
   installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'asString' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newString: rcvr integer asString) ]).
 
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'sqrt' in: universe with: [:frame :interp |
+        | rcvr result |
+        rcvr := frame pop.
+        result := rcvr integer sqrt.
+        result class == SInteger
+          ifTrue: [frame push: (universe newInteger: result)]
+          ifFalse: [frame push: (universe newDouble: result)] ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'atRandom' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: rcvr integer atRandom) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '+' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+
+        frame push: (argument class == SDouble
+          ifTrue: [universe newDouble: rcvr integer + argument double]
+          ifFalse: [universe newInteger: rcvr integer + argument integer]) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '-' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+
+        frame push: (argument class == SDouble
+          ifTrue: [universe newDouble: rcvr integer - argument double]
+          ifFalse: [universe newInteger: rcvr integer - argument integer]) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '*' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+
+        frame push: (argument class == SDouble
+          ifTrue: [universe newDouble: rcvr integer * argument double]
+          ifFalse: [universe newInteger: rcvr integer * argument integer]) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '//' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+
+        frame push: (universe newDouble:
+          (argument class == SDouble
+            ifTrue: [rcvr integer // argument double]
+            ifFalse: [rcvr integer // argument integer])) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '/' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+
+        frame push: (universe newInteger:
+          (argument class == SDouble
+            ifTrue: [rcvr integer / argument double]
+            ifFalse: [rcvr integer / argument integer])) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '%' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+
+        frame push: (argument class == SDouble
+            ifTrue: [universe newDouble: rcvr integer % argument double]
+            ifFalse: [universe newInteger: rcvr integer % argument integer]) ]).
+
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'rem:' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+        frame push: (universe newInteger: (rcvr integer rem: argument integer))]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '&' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+        frame push: (universe newInteger: (rcvr integer & argument integer)) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '=' in: universe with: [:frame :interp |
+        | argument rcvr left |
+        argument := frame pop.
+        rcvr := frame pop.
+        left := rcvr integer.
+
+        frame push: ((
+          (argument class == SDouble)
+            ifTrue: [left = argument double]
+            ifFalse: [
+              argument class == SInteger
+                ifTrue: [left = argument integer]
+                ifFalse: [ false ] ])
+            ifTrue: [universe trueObject]
+            ifFalse: [universe falseObject] ) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '<<' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+        frame push: (universe newInteger: (rcvr integer << argument integer)) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '<' in: universe with: [:frame :interp |
+        | argument rcvr left |
+        argument := frame pop.
+        rcvr := frame pop.
+        left := rcvr integer.
+
+        frame push: ((
+          (argument class == SDouble)
+            ifTrue: [left < argument double]
+            ifFalse: [
+              argument class == SInteger
+                ifTrue: [left < argument integer]
+                ifFalse: [ false ] ])
+            ifTrue: [universe trueObject]
+            ifFalse: [universe falseObject] ) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'bitXor:' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+        frame push: (universe newInteger: (rcvr integer bitXor: argument integer)) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'as32BitSignedValue' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: (rcvr integer as32BitSignedValue)) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'as32BitUnsignedValue' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: (rcvr integer as32BitUnsignedValue)) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '>>>' in: universe with: [:frame :interp |
+        | argument rcvr |
+        argument := frame pop.
+        rcvr := frame pop.
+        frame push: (universe newInteger: (rcvr integer >>> argument integer)) ]).
+
+    self installClassPrimitive: (
+      SPrimitive new: 'fromString:' in: universe with: [:frame :interp |
+        | argument |
+        argument := frame pop.
+        frame push: (universe newInteger: (Integer fromString: argument string)) ]).
   )
 
   ----

--- a/SomSom/src/primitives/IntegerPrimitives.som
+++ b/SomSom/src/primitives/IntegerPrimitives.som
@@ -1,0 +1,12 @@
+IntegerPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/IntegerPrimitives.som
+++ b/SomSom/src/primitives/IntegerPrimitives.som
@@ -167,6 +167,7 @@ IntegerPrimitives = Primitives (
       SPrimitive new: 'fromString:' in: universe with: [:frame :interp |
         | argument |
         argument := frame pop.
+        frame pop.
         frame push: (universe newInteger: (Integer fromString: argument string)) ]).
   )
 

--- a/SomSom/src/primitives/MethodPrimitives.som
+++ b/SomSom/src/primitives/MethodPrimitives.som
@@ -1,7 +1,17 @@
 MethodPrimitives = Primitives (
 
   installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'holder' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr holder ]).
 
+    self installInstancePrimitive: (
+      SPrimitive new: 'signature' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr signature ]).
   )
 
   ----

--- a/SomSom/src/primitives/MethodPrimitives.som
+++ b/SomSom/src/primitives/MethodPrimitives.som
@@ -1,0 +1,12 @@
+MethodPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/ObjectPrimitives.som
+++ b/SomSom/src/primitives/ObjectPrimitives.som
@@ -1,7 +1,95 @@
 ObjectPrimitives = Primitives (
 
   installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: '==' in: universe with: [:frame :interp |
+        | op1 op2 |
+        op1 := frame pop.
+        op2 := frame pop.
 
+        frame push: (op1 == op2
+          ifTrue: [ universe trueObject ]
+          ifFalse: [ universe falseObject ]) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'hashcode' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: rcvr hashcode) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'objectSize' in: universe with: [:frame :interp |
+        | rcvr size clazz |
+        rcvr := frame pop.
+
+        size := 1.
+        clazz := (rcvr somClassIn: universe).
+        clazz == SArray ifTrue: [
+          size := size + rcvr numberOfIndexableFields ].
+        clazz == SObject ifTrue: [
+          size := size + rcvr numberOfFields ].
+
+        frame push: (universe newInteger: size) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'perform:' in: universe with: [:frame :interp |
+        | selector rcvr invokable |
+        selector := frame pop.
+        rcvr := frame stackElement: 0.
+
+        invokable := (rcvr somClassIn: universe) lookupInvokable: selector.
+        invokable invoke: frame using: interp ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'perform:inSuperclass:' in: universe with: [:frame :interp |
+        | selector clazz invokable |
+        clazz := frame pop.
+        selector := frame pop.
+
+        invokable := clazz lookupInvokable: selector.
+        invokable invoke: frame using: interp ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'perform:withArguments:' in: universe with: [:frame :interp |
+        | args selector rcvr invokable |
+        args := frame pop.
+        selector := frame pop.
+        rcvr := frame stackElement: 0.
+
+        1 to: args numberOfIndexableFields do: [:i |
+          frame push: (args indexableField: i) ].
+
+        invokable := (rcvr somClassIn: universe) lookupInvokable: selector.
+        invokable invoke: frame using: interp ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'instVarAt:' in: universe with: [:frame :interp |
+        | idx rcvr invokable |
+        idx := frame pop.
+        rcvr := frame pop.
+
+        frame push: (rcvr field: idx integer) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'instVarAt:put:' in: universe with: [:frame :interp |
+        | idx rcvr invokable val |
+        val := frame pop.
+        idx := frame pop.
+        rcvr := frame stackElement: 0.
+
+        rcvr field: idx integer put: val ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'class' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (rcvr somClassIn: universe) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'halt' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame stackElement: 0.
+        rcvr halt ]).
   )
 
   ----

--- a/SomSom/src/primitives/ObjectPrimitives.som
+++ b/SomSom/src/primitives/ObjectPrimitives.som
@@ -1,0 +1,12 @@
+ObjectPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/ObjectPrimitives.som
+++ b/SomSom/src/primitives/ObjectPrimitives.som
@@ -7,9 +7,7 @@ ObjectPrimitives = Primitives (
         op1 := frame pop.
         op2 := frame pop.
 
-        frame push: (op1 == op2
-          ifTrue: [ universe trueObject ]
-          ifFalse: [ universe falseObject ]) ]).
+        frame push: (self somBool: op1 == op2) ]).
 
     self installInstancePrimitive: (
       SPrimitive new: 'hashcode' in: universe with: [:frame :interp |

--- a/SomSom/src/primitives/PrimitivePrimitives.som
+++ b/SomSom/src/primitives/PrimitivePrimitives.som
@@ -1,0 +1,12 @@
+PrimitivePrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/PrimitivePrimitives.som
+++ b/SomSom/src/primitives/PrimitivePrimitives.som
@@ -1,7 +1,17 @@
 PrimitivePrimitives = Primitives (
 
   installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'holder' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr holder ]).
 
+    self installInstancePrimitive: (
+      SPrimitive new: 'signature' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: rcvr signature ]).
   )
 
   ----

--- a/SomSom/src/primitives/Primitives.som
+++ b/SomSom/src/primitives/Primitives.som
@@ -1,0 +1,24 @@
+Primitives = (
+  | universe holder |
+  initialize: aUniverse = (
+    universe := aUniverse
+  )
+
+  installPrimitivesIn: aSClass = (
+    holder := aSClass.
+
+    self installPrimitives
+  )
+
+  installInstancePrimitive: prim = (
+    self installInstancePrimitive: prim dontWarn: false
+  )
+
+  installInstancePrimitive: prim dontWarn: suppressWarning = (
+    holder addInstancePrimitive: prim dontWarn: suppressWarning
+  )
+
+  installClassPrimitive: prim = (
+    holder somClass addInstancePrimitive: prim
+  )
+)

--- a/SomSom/src/primitives/Primitives.som
+++ b/SomSom/src/primitives/Primitives.som
@@ -21,4 +21,10 @@ Primitives = (
   installClassPrimitive: prim = (
     holder somClass addInstancePrimitive: prim
   )
+
+  somBool: aBool = (
+    ^ aBool
+        ifTrue: [ universe trueObject ]
+        ifFalse: [ universe falseObject ]
+  )
 )

--- a/SomSom/src/primitives/StringPrimitives.som
+++ b/SomSom/src/primitives/StringPrimitives.som
@@ -1,0 +1,12 @@
+StringPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/StringPrimitives.som
+++ b/SomSom/src/primitives/StringPrimitives.som
@@ -27,9 +27,9 @@ StringPrimitives = Primitives (
         argument := frame pop.
         rcvr := frame pop.
 
-        frame push: ((argument somClassIn: universe) and: [rcvr string = argument string]) == universe stringClass
-          ifTrue: [ universe trueObject ]
-          ifFalse: [ universe falseObject ] ]).
+        frame push: (self somBool:
+          ((argument somClassIn: universe) == universe stringClass
+            and: [rcvr string = argument string])) ]).
 
     self installInstancePrimitive: (
       SPrimitive new: 'primSubstringFrom:to:' in: universe with: [:frame :interp |
@@ -50,25 +50,19 @@ StringPrimitives = Primitives (
       SPrimitive new: 'isWhiteSpace' in: universe with: [:frame :interp |
         | rcvr |
         rcvr := frame pop.
-        frame push: (rcvr string isWhiteSpace
-          ifTrue: [ universe trueObject ]
-          ifFalse: [ universe falseObject ] ) ]).
+        frame push: (self somBool: rcvr string isWhiteSpace) ]).
 
     self installInstancePrimitive: (
       SPrimitive new: 'isLetters' in: universe with: [:frame :interp |
         | rcvr |
         rcvr := frame pop.
-        frame push: (rcvr string isLetters
-          ifTrue: [ universe trueObject ]
-          ifFalse: [ universe falseObject ] ) ]).
+        frame push: (self somBool: rcvr string isLetters) ]).
 
     self installInstancePrimitive: (
       SPrimitive new: 'isDigits' in: universe with: [:frame :interp |
         | rcvr |
         rcvr := frame pop.
-        frame push: (rcvr string isDigits
-          ifTrue: [ universe trueObject ]
-          ifFalse: [ universe falseObject ] ) ]).
+        frame push: (self somBool: rcvr string isDigits) ]).
   )
 
   ----

--- a/SomSom/src/primitives/StringPrimitives.som
+++ b/SomSom/src/primitives/StringPrimitives.som
@@ -1,7 +1,74 @@
 StringPrimitives = Primitives (
 
   installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'concatenate:' in: universe with: [:frame :interp |
+        | rcvr argument |
+        argument := frame pop.
+        rcvr := frame pop.
 
+        frame push: (universe newString: rcvr string + argument string) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'asSymbol' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe symbolFor: rcvr string) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'length' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: rcvr string length) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '=' in: universe with: [:frame :interp |
+        | rcvr argument |
+        argument := frame pop.
+        rcvr := frame pop.
+
+        frame push: ((argument somClassIn: universe) and: [rcvr string = argument string]) == universe stringClass
+          ifTrue: [ universe trueObject ]
+          ifFalse: [ universe falseObject ] ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'primSubstringFrom:to:' in: universe with: [:frame :interp |
+        | rcvr from to |
+        to := frame pop.
+        from := frame pop.
+        rcvr := frame pop.
+
+        frame push: (universe newString: (rcvr string primSubstringFrom: from integer to: to integer)) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'hashcode' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (universe newInteger: rcvr string hashcode) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'isWhiteSpace' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (rcvr string isWhiteSpace
+          ifTrue: [ universe trueObject ]
+          ifFalse: [ universe falseObject ] ) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'isLetters' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (rcvr string isLetters
+          ifTrue: [ universe trueObject ]
+          ifFalse: [ universe falseObject ] ) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'isDigits' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
+        frame push: (rcvr string isDigits
+          ifTrue: [ universe trueObject ]
+          ifFalse: [ universe falseObject ] ) ]).
   )
 
   ----

--- a/SomSom/src/primitives/SymbolPrimitives.som
+++ b/SomSom/src/primitives/SymbolPrimitives.som
@@ -14,9 +14,7 @@ SymbolPrimitives = Primitives (
         arg := frame pop.
         rcvr := frame pop.
 
-        frame push: (rcvr == arg
-          ifTrue: [universe trueObject]
-          ifFalse: [universe falseObject]) ] ) dontWarn: true.
+        frame push: (self somBool: rcvr == arg) ] ) dontWarn: true.
   )
 
   ----

--- a/SomSom/src/primitives/SymbolPrimitives.som
+++ b/SomSom/src/primitives/SymbolPrimitives.som
@@ -1,0 +1,12 @@
+SymbolPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/SymbolPrimitives.som
+++ b/SomSom/src/primitives/SymbolPrimitives.som
@@ -1,7 +1,22 @@
 SymbolPrimitives = Primitives (
 
   installPrimitives = (
+    self installInstancePrimitive: (
+      SPrimitive new: 'asString' in: universe with: [:frame :interp |
+        | rcvr |
+        rcvr := frame pop.
 
+        frame push: (universe newString: rcvr string) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: '=' in: universe with: [:frame :interp |
+        | rcvr arg |
+        arg := frame pop.
+        rcvr := frame pop.
+
+        frame push: (rcvr == arg
+          ifTrue: [universe trueObject]
+          ifFalse: [universe falseObject]) ] ) dontWarn: true.
   )
 
   ----

--- a/SomSom/src/primitives/SystemPrimitives.som
+++ b/SomSom/src/primitives/SystemPrimitives.som
@@ -1,0 +1,12 @@
+SystemPrimitives = Primitives (
+
+  installPrimitives = (
+
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+)

--- a/SomSom/src/primitives/SystemPrimitives.som
+++ b/SomSom/src/primitives/SystemPrimitives.som
@@ -1,7 +1,103 @@
 SystemPrimitives = Primitives (
-
   installPrimitives = (
 
+    self installInstancePrimitive: (
+      SPrimitive new: 'load:' in: universe with: [:frame :interp |
+        | arg result |
+        arg := frame pop.
+        frame pop.
+
+        result := universe loadClass: arg.
+
+        frame push: (result == nil
+          ifTrue: [ universe nilObject ]
+          ifFalse: [ result ]) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'exit:' in: universe with: [:frame :interp |
+        | error |
+        frame printStackTrace.
+        error := frame pop.
+        universe exit: error integer ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'global:' in: universe with: [:frame :interp |
+        | argument result |
+        argument := frame pop.
+        frame pop.
+
+        result := universe global: argument.
+        frame push: (result == nil
+          ifTrue: [ universe nilObject ]
+          ifFalse: [ result ]) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'global:put:' in: universe with: [:frame :interp |
+        | value argument |
+        value := frame pop.
+        argument := frame pop.
+
+        universe global: argument put: value ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'printString:' in: universe with: [:frame :interp |
+        | arg |
+        arg := frame pop.
+        "Universe print: arg somClass asString."
+        Universe print: arg string ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'printNewline' in: universe with: [:frame :interp |
+        Universe println ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'errorPrint:' in: universe with: [:frame :interp |
+        | arg |
+        arg := frame pop.
+        Universe errorPrint: arg string ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'errorPrintln:' in: universe with: [:frame :interp |
+        | arg |
+        arg := frame pop.
+        Universe errorPrintln: arg string ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'time' in: universe with: [:frame :interp |
+        | time |
+        frame pop. "ignore"
+        time := system time.
+        frame push: (universe newInteger: time) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'ticks' in: universe with: [:frame :interp |
+        | ticks |
+        frame pop. "ignore"
+        ticks := system ticks.
+        frame push: (universe newInteger: ticks) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'fullGC' in: universe with: [:frame :interp |
+        frame pop. "ignore"
+        system fullGC.
+        frame push: (universe trueObject) ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'loadFile:' in: universe with: [:frame :interp |
+        | fileName content |
+        fileName := frame pop.
+        frame pop.
+
+        content := system loadFile: fileName string.
+        content == nil
+          ifTrue: [frame push: universe nilObject]
+          ifFalse: [frame push: (universe newString: content)] ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'printStackTrace' in: universe with: [:frame :interp |
+        frame pop. "ignore"
+        frame printStackTrace.
+        frame push: (universe trueObject) ]).
   )
 
   ----

--- a/SomSom/src/vm/Main.som
+++ b/SomSom/src/vm/Main.som
@@ -1,0 +1,14 @@
+Main = (
+  run: args = (
+    | u args2 |
+    u := Universe new.
+
+    '-- args' println.
+    args do: [:a | a println].
+
+    args2 := args copyFrom: 2.
+
+    u interpret: args2.
+    u exit: 0.
+  )
+)

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -90,14 +90,17 @@ Universe = (
   )
 
   handleArguments: args = (
-    | gotClasspath remainingArgs cnt i |
+    | gotClasspath remainingArgs cnt i sawOthers |
     gotClasspath := false.
     remainingArgs := Vector new.
+
+    "read dash arguments only while we haven't seen other kind of arguments"
+    sawOthers := false.
 
     i := 1.
 
     [i <= args length] whileTrue: [
-      (args at: i) = '-cp'
+      ((args at: i) = '-cp' and: sawOthers not)
         ifTrue: [
           i + 1 > args length ifTrue: [
             self printUsageAndExit ].
@@ -105,20 +108,22 @@ Universe = (
           i := i + 1.
           gotClasspath := true ]
         ifFalse: [
-          (args at: i) = '-d'
+          ((args at: i) = '-d' and: sawOthers not)
             ifTrue: [ dumpBytecodes := true ]
-            ifFalse: [ remainingArgs append: (args at: i) ] ].
+            ifFalse: [
+              sawOthers := true.
+              remainingArgs append: (args at: i) ] ].
         i := i + 1 ].
 
     gotClasspath ifFalse: [
       classPath := self defaultClassPath ].
 
-    remainingArgs doIndexes: [:i |
+    remainingArgs isEmpty ifFalse: [
       | split |
-      split := self pathClassExtension: (remainingArgs at: i).
+      split := self pathClassExtension: (remainingArgs at: 1).
       (split at: 1) = '' ifFalse: [
-        classPath := classPath extendedWith: (split at: 1) ].
-      remainingArgs at: i put: (split at: 2) ].
+        classPath := classPath prependedWith: (split at: 1) ].
+      remainingArgs at: 1 put: (split at: 2) ].
 
     ^ remainingArgs asArray
   )

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -2,6 +2,7 @@ Universe = (
   | symbolTable globals classPath dumpBytecodes interpreter
 
     avoidExit
+    lastExitCode
 
     nilObject
     trueObject
@@ -37,6 +38,22 @@ Universe = (
   initialize: aBool = (
     self initialize.
     avoidExit := aBool
+  )
+
+  exit: errorCode = (
+    "Exit from the Java system"
+    avoidExit
+      ifTrue: [lastExitCode := errorCode]
+      ifFalse: [system exit: errorCode]
+  )
+
+  lastExitCode = (
+    ^ lastExitCode
+  )
+
+  errorExit: message = (
+    Universe errorPrintln: 'Runtime Error: ' + message.
+    self exit: 1
   )
 
   nilObject   = ( ^ nilObject )

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -45,6 +45,7 @@ Universe = (
   metaclassClass = ( ^ metaclassClass )
 
   arrayClass  = ( ^ arrayClass )
+  blockClass  = ( ^ blockClass )
   doubleClass = ( ^ doubleClass )
   integerClass = ( ^ integerClass )
   methodClass = ( ^ methodClass )
@@ -239,7 +240,7 @@ Universe = (
   )
 
   newBlock: method with: context numArgs: arguments = (
-    ^ SBlock new: method with: context numArgs: (self blockClass: arguments)
+    ^ SBlock new: method in: context with: (self blockClass: arguments)
   )
 
   newClass: classClass = (
@@ -366,6 +367,25 @@ Universe = (
   hasGlobal: aSSymbol = (
     "Returns if the universe has a value for the global of the given name"
     ^ globals containsKey: aSSymbol
+  )
+
+  blockClass: numberOfArguments = (
+    | name result |
+    "Determine the name of the block class with the given number of arguments"
+    name := self symbolFor: 'Block' + numberOfArguments.
+
+    "Lookup the block class in the dictionary of globals and return it"
+    (self hasGlobal: name) ifTrue: [
+      ^ self global: name ].
+
+    result := self loadClass: name into: nil.
+
+    "Add the appropriate value primitive to the block class"
+    result addInstancePrimitive:
+      (SBlock evaluationPrimitive: numberOfArguments in: self).
+
+    self global: name put: result.
+    ^ result
   )
 
   loadClass: name = (

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -86,6 +86,61 @@ Universe = (
     classPath := cps asArray
   )
 
+  handleArguments: args = (
+    | gotClasspath remainingArgs cnt i |
+    gotClasspath := false.
+    remainingArgs := Vector new.
+
+    i := 1.
+
+    [i <= args length] whileTrue: [
+      (args at: i) = '-cp'
+        ifTrue: [
+          i + 1 > args length ifTrue: [
+            self printUsageAndExit ].
+          self setupClassPath: (args at: i + 1).
+          i := i + 1.
+          gotClasspath := true ]
+        ifFalse: [
+          (args at: i) = '-d'
+            ifTrue: [ dumpBytecodes := true ]
+            ifFalse: [ remainingArgs append: (args at: i) ] ].
+        i := i + 1 ].
+
+    gotClasspath ifFalse: [
+      classPath := self defaultClassPath ].
+
+    remainingArgs doIndexes: [:i |
+      | split |
+      split := self pathClassExtension: (remainingArgs at: i).
+      (split at: 1) = '' ifFalse: [
+        classPath := classPath extendedWith: (split at: 1) ].
+      remainingArgs at: i put: (split at: 2) ].
+
+    ^ remainingArgs asArray
+  )
+
+  pathClassExtension: str = (
+    | pathElements fileName parentPath nameParts |
+    pathElements := str split: '/'.
+    fileName := pathElements last.
+
+    parentPath := ''.
+    1 to: pathElements length - 1 do: [:i |
+      parentPath = '' ifFalse: [
+        parentPath := parentPath + '/' ].
+      parentPath := parentPath + (pathElements at: i) ].
+
+    nameParts := fileName split: '.'.
+    ^ Array with: parentPath with: (nameParts at: 1)
+  )
+
+  interpret: args = (
+    | remainingArgs |
+    remainingArgs := self handleArguments: args.
+    ^ self initializeInterpreter: remainingArgs.
+  )
+
   interpret: className with: selector = (
     | clazz initialize |
     self initializeObjectSystem.
@@ -101,12 +156,12 @@ Universe = (
     ^ self interpret: initialize in: clazz with: nil
   )
 
-  initialize: arguments = (
+  initializeInterpreter: arguments = (
     | systemObject initialize argumentsArray |
     systemObject := self initializeObjectSystem.
 
     "Start the shell if no filename is given"
-    arguments size == 0 ifTrue: [
+    arguments length == 0 ifTrue: [
       | shell |
       shell := Shell for: self using: interpreter.
       shell bootstrapMethod: self createBootstrapMethod.
@@ -116,7 +171,7 @@ Universe = (
     initialize := systemClass lookupInvokable: (self symbolFor: 'initialize:').
 
     "Convert the arguments into an array"
-    argumentsArray := self newArray: arguments.
+    argumentsArray := self newArrayFromStrings: arguments.
 
     ^ self interpret: initialize in: systemObject with: argumentsArray
   )
@@ -241,6 +296,14 @@ Universe = (
 
   newArray: size = (
     ^ SArray new: size with: nilObject
+  )
+
+  newArrayFromStrings: strArray = (
+    | sArr |
+    sArr := self newArray: strArray length.
+    1 to: strArray length do: [:i |
+      sArr indexableField: i put: (self newString: (strArray at: i))].
+    ^ sArr
   )
 
   newArrayFromVector: vector = (

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -230,6 +230,10 @@ Universe = (
     ^ result
   )
 
+  newBlock: method with: context numArgs: arguments = (
+    ^ SBlock new: method with: context numArgs: (self blockClass: arguments)
+  )
+
   newClass: classClass = (
     | result |
     "Allocate a new class and set its class to be the given class class"

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -1,7 +1,199 @@
 Universe = (
-  | symbolTable |
+  | symbolTable globals classPath dumpBytecodes interpreter
+
+    nilObject
+    trueObject
+    falseObject
+
+    objectClass
+    classClass
+    metaclassClass
+
+    nilClass
+    integerClass
+    arrayClass
+    methodClass
+    symbolClass
+    primClass
+    stringClass
+    systemClass
+    blockClass
+    doubleClass
+
+    trueClass
+    falseClass
+  |
+
   initialize = (
     symbolTable := Dictionary new.
+    globals := Dictionary new.
+    interpreter := Interpreter new: self.
+    dumpBytecodes := false.
+  )
+
+  nilObject   = ( ^ nilObject )
+  trueObject  = ( ^ trueObject )
+  falseObject = ( ^ falseObject )
+  metaclassClass = ( ^ metaclassClass )
+
+  defaultClassPath = (
+    ^ #('.')
+  )
+
+  setupClassPath: cp = (
+    | paths cps |
+    "Create a new tokenizer to split up the string of directories"
+    paths := cp split: ':'.
+
+    cps := Vector new.
+    cps appendAll: self defaultClassPath.
+    cps appendAll: paths.
+
+    classPath := cps asArray
+  )
+
+  interpret: className with: selector = (
+    | clazz initialize |
+    self initializeObjectSystem.
+
+    clazz := self loadClass: (self symbolFor: className).
+
+    "Lookup the initialize invokable on the system class"
+    initialize := (clazz somClass: self) lookupInvokable: (self symbolFor: selector).
+
+    initialize == nil ifTrue: [
+      self error: 'Lookup of ' + className + '>>#' + selector + ' failed' ].
+
+    ^ self interpret: initialize in: clazz with: nil
+  )
+
+  initialize: arguments = (
+    | systemObject initialize argumentsArray |
+    systemObject := self initializeObjectSystem.
+
+    "Start the shell if no filename is given"
+    arguments size == 0 ifTrue: [
+      | shell |
+      shell := Shell for: self using: interpreter.
+      shell bootstrapMethod: self createBootstrapMethod.
+      ^ shell start ].
+
+    "Lookup the initialize invokable on the system class"
+    initialize := systemClass lookupInvokable: (self symbolFor: 'initialize:').
+
+    "Convert the arguments into an array"
+    argumentsArray := self newArray: arguments.
+
+    ^ self interpret: initialize in: systemObject with: argumentsArray
+  )
+
+  createBootstrapMethod = (
+    | bootstrapMethod |
+    "Create a fake bootstrap method to simplify later frame traversal"
+    bootstrapMethod := self newMethod: (self symbolFor: 'bootstrap')
+      bc: #(#halt) literals: #() numLocals: 0 maxStack: 2.
+
+    bootstrapMethod holder: systemClass.
+    ^ bootstrapMethod
+  )
+
+  interpret: invokable in: receiver with: arguments = (
+    | bootstrapMethod bootstrapFrame |
+    bootstrapMethod := self createBootstrapMethod.
+
+    "Create a fake bootstrap frame with the system object on the stack"
+    bootstrapFrame := interpreter pushNewFrame: bootstrapMethod.
+    bootstrapFrame push: receiver.
+
+    arguments ~= nil ifTrue: [
+      bootstrapFrame push: arguments ].
+
+    "Invoke the initialize invokable"
+    invokable invoke: bootstrapFrame using: interpreter.
+
+    "Start the interpreter"
+    ^ interpreter start
+  )
+
+  initializeObjectSystem = (
+    | trueSymbol falseSymbol systemObject |
+
+    "Allocate the nil object"
+    nilObject := SObject new.
+
+    "Allocate the Metaclass classes"
+    metaclassClass := self newMetaclassClass.
+
+    "Allocate the rest of the system classes"
+    objectClass := self newSystemClass.
+    nilClass := self newSystemClass.
+    classClass := self newSystemClass.
+    arrayClass := self newSystemClass.
+    symbolClass := self newSystemClass.
+    methodClass := self newSystemClass.
+    integerClass := self newSystemClass.
+    primClass := self newSystemClass.
+    stringClass := self newSystemClass.
+    doubleClass := self newSystemClass.
+
+    "Setup the class reference for the nil object"
+    nilObject somClass: nilClass.
+
+    "Initialize the system classes."
+    self initializeSystemClass: objectClass superClass: nil name: 'Object'.
+    self initializeSystemClass: classClass superClass: objectClass name: 'Class'.
+    self initializeSystemClass: metaclassClass superClass: classClass name: 'Metaclass'.
+    self initializeSystemClass: nilClass superClass: objectClass name: 'Nil'.
+    self initializeSystemClass: arrayClass superClass: objectClass name: 'Array'.
+    self initializeSystemClass: methodClass superClass: arrayClass name: 'Method'.
+    self initializeSystemClass: stringClass superClass: objectClass name: 'String'.
+    self initializeSystemClass: symbolClass superClass: stringClass name: 'Symbol'.
+    self initializeSystemClass: integerClass superClass: objectClass name: 'Integer'.
+    self initializeSystemClass: primClass superClass: objectClass name: 'Primitive'.
+    self initializeSystemClass: doubleClass superClass: objectClass name: 'Double'.
+
+    "Load methods and fields into the system classes"
+    self loadSystemClass: objectClass.
+    self loadSystemClass: classClass.
+    self loadSystemClass: metaclassClass.
+    self loadSystemClass: nilClass.
+    self loadSystemClass: arrayClass.
+    self loadSystemClass: methodClass.
+    self loadSystemClass: symbolClass.
+    self loadSystemClass: integerClass.
+    self loadSystemClass: primClass.
+    self loadSystemClass: stringClass.
+    self loadSystemClass: doubleClass.
+
+    "Fix up objectClass"
+    objectClass superClass: nilObject.
+
+    "Load the generic block class"
+    blockClass := self loadClass: (self symbolFor: 'Block').
+
+    "Setup the true and false objects"
+    trueSymbol := self symbolFor: 'True'.
+    trueClass := self loadClass: trueSymbol.
+    trueObject := self newInstance: trueClass.
+
+    falseSymbol := self symbolFor: 'False'.
+    falseClass := self loadClass: falseSymbol.
+    falseObject := self newInstance: falseClass.
+
+    "Load the system class and create an instance of it"
+    systemClass := self loadClass: (self symbolFor: 'System').
+    systemObject := self newInstance: systemClass.
+
+    "Put special objects and classes into the dictionary of globals"
+    self global: (self symbolFor: 'nil') put: nilObject.
+    self global: (self symbolFor: 'true') put: trueObject.
+    self global: (self symbolFor: 'false') put: falseObject.
+    self global: (self symbolFor: 'system') put: systemObject.
+    self global: (self symbolFor: 'System') put: systemClass.
+    self global: (self symbolFor: 'Block') put: blockClass.
+    self global: trueSymbol  put: trueClass.
+    self global: falseSymbol put: falseClass.
+    ^ systemObject
   )
 
   symbolFor: aString = (
@@ -13,10 +205,45 @@ Universe = (
     ^ self newSymbol: aString
   )
 
+  newArray: size = (
+    ^ SArray new: size with: nilObject
+  )
+
+  newArrayFromVector: vector = (
+    | result |
+    "Allocate a new array with the same length as the list"
+    result := self newArray: vector size.
+
+    "Copy all elements from the list into the array"
+    vector doIndexes: [:i |
+      result indexableField: i put: (vector at: i) ].
+
+    "Return the allocated and initialized array"
+    ^ result
+  )
+
+  newClass: classClass = (
+    | result |
+    "Allocate a new class and set its class to be the given class class"
+    result := SClass new: classClass numberOfInstanceFields in: self.
+    result somClass: classClass.
+
+    "Return the freshly allocated class"
+    ^ result
+  )
+
   newSymbol: aString = (
     | result |
     result := SSymbol new: aString.
     symbolTable at: aString put: result.
+    ^ result
+  )
+
+  newInstance: instanceClass = (
+    | result |
+    result := SObject new: instanceClass numberOfInstanceFields with: nilObject.
+    result somClass: instanceClass.
+
     ^ result
   )
 
@@ -28,13 +255,164 @@ Universe = (
     ^ SDouble for: aDouble
   )
 
+  newMetaclassClass = (
+    | result |
+    "Allocate the metaclass classes"
+    result := SClass new: self.
+    result somClass: (SClass new: self).
+
+    "Setup the metaclass hierarchy"
+    result somClass somClass: result.
+
+    "Return the freshly allocated metaclass class"
+    ^ result
+  )
+
+  newMethod: aSSymbol bc: bcArray literals: literalsArray numLocals: numLocals maxStack: maxStack = (
+    ^ SMethod new: aSSymbol bc: bcArray literals: literalsArray numLocals: numLocals maxStack: maxStack
+  )
+
   newString: aString = (
     ^ SString new: aString
+  )
+
+  newSystemClass = (
+    | symbolClass |
+    "Allocate the new system class"
+    systemClass := SClass new: self.
+
+    "Setup the metaclass hierarchy"
+    systemClass somClass: (SClass new: self).
+    systemClass somClass somClass: metaclassClass.
+
+    "Return the freshly allocated system class"
+    ^ systemClass
+  )
+
+  initializeSystemClass: systemClass superClass: superClass name: name = (
+    "Initialize the superclass hierarchy"
+    superClass ~= nil
+      ifTrue: [
+        systemClass superClass: superClass.
+        systemClass somClass superClass: (superClass somClass) ]
+      ifFalse: [
+        systemClass somClass superClass: classClass ].
+
+    "Initialize the array of instance fields"
+    systemClass instanceFields: (self newArray: 0).
+    systemClass somClass instanceFields: (self newArray: 0).
+
+    "Initialize the array of instance invokables"
+    systemClass instanceInvokables: (self newArray: 0).
+    systemClass somClass instanceInvokables: (self newArray: 0).
+
+    "Initialize the name of the system class"
+    systemClass name: (self symbolFor: name).
+    systemClass somClass name: (self symbolFor: name + ' class').
+
+    "Insert the system class into the dictionary of globals"
+    self global: systemClass name put: systemClass.
+  )
+
+  global: aSSymbol = (
+    "Return the global with the given name if it's in the dictionary of globals"
+    (self hasGlobal: aSSymbol) ifTrue: [
+      ^ globals at: aSSymbol ].
+
+    "Global not found"
+    ^ nil
+  )
+
+  global: aSSymbol put: aSAbstractObject = (
+    "Insert the given value into the dictionary of globals"
+    globals at: aSSymbol put: aSAbstractObject
+  )
+
+  hasGlobal: aSSymbol = (
+    "Returns if the universe has a value for the global of the given name"
+    ^ globals containsKey: aSSymbol
+  )
+
+  loadClass: name = (
+    | result |
+    "Check if the requested class is already in the dictionary of globals"
+    (self hasGlobal: name) ifTrue: [
+      ^ self global: name ].
+
+    "Load the class"
+    result := self loadClass: name into: nil.
+
+    "Load primitives (if necessary) and return the resulting class"
+    (result ~= nil and: [result hasPrimitives]) ifTrue: [
+      result loadPrimitives ].
+
+    self global: name put: result.
+    ^ result
+  )
+
+  loadSystemClass: systemClass = (
+    | result |
+    "Load the system class"
+    result := self loadClass: systemClass name into: systemClass.
+
+    "Load primitives if necessary"
+    result hasPrimitives ifTrue: [
+      result loadPrimitives ].
+  )
+
+  loadClass: name into: systemClass = (
+    "Try loading the class from all different paths"
+    classPath do: [:cpEntry |
+      | result |
+      "Load the class from a file and return the loaded class"
+      result := SourcecodeCompiler compileClass: cpEntry name: name string into: systemClass in: self.
+
+      (result notNil and: dumpBytecodes) ifTrue: [
+        Disassembler dump: result somClass.
+        Disassembler dump: result ].
+
+      result ifNotNil: [ ^ result ] ].
+
+    "The class could not be found."
+    ^ nil
+  )
+
+  loadShellClass: stmt = (
+    | result |
+    "Load the class from a stream and return the loaded class"
+    result := SourcecodeCompiler compileClass: stmt into: nil in: self.
+    dumpBytecodes ifTrue: [
+      Disassembler dump: result ].
+    ^ result
   )
 
   ----
 
   new = (
     ^ super new initialize
+  )
+
+  errorPrint: msg = (
+    system errorPrint: msg
+  )
+
+  errorPrintln: msg = (
+    system errorPrintln: msg
+  )
+
+  errorPrintln = (
+    system errorPrintln: ''
+  )
+
+  print: msg = (
+    system errorPrint: msg
+  )
+
+  println: msg = (
+    system errorPrintln: msg
+  )
+
+  println = (
+    system errorPrintln
   )
 )

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -3,6 +3,7 @@ Universe = (
 
     avoidExit
     lastExitCode
+    exitBlock
 
     nilObject
     trueObject
@@ -43,7 +44,9 @@ Universe = (
   exit: errorCode = (
     "Exit from the Java system"
     avoidExit
-      ifTrue: [lastExitCode := errorCode]
+      ifTrue: [
+        lastExitCode := errorCode.
+        exitBlock value: errorCode ]
       ifFalse: [system exit: errorCode]
   )
 
@@ -191,6 +194,8 @@ Universe = (
 
   interpret: invokable in: receiver with: arguments = (
     | bootstrapMethod bootstrapFrame |
+    exitBlock := [:errorCode | ^ errorCode ].
+
     bootstrapMethod := self createBootstrapMethod.
 
     "Create a fake bootstrap frame with the system object on the stack"

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -1,0 +1,28 @@
+Universe = (
+  | symbolTable |
+  initialize = (
+    symbolTable := Dictionary new.
+  )
+
+  symbolFor: aString = (
+    | result |
+    result := symbolTable at: aString.
+    result == nil ifFalse: [
+      ^ result ].
+
+    ^ self newSymbol: aString
+  )
+
+  newSymbol: aString = (
+    | result |
+    result := SSymbol new: aString.
+    symbolTable at: aString put: result.
+    ^ result
+  )
+
+  ----
+
+  new = (
+    ^ super new initialize
+  )
+)

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -255,10 +255,6 @@ Universe = (
 
     result := Frame new: nilObject previous: previousFrame context: contextFrame method: method maxStack: length.
 
-    "Reset the stack pointer and the bytecode index"
-    result resetStackPointer.
-    result bytecodeIndex: 1.
-
     "Return the freshly allocated frame"
     ^ result
   )

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -20,6 +20,18 @@ Universe = (
     ^ result
   )
 
+  newInteger: anInteger = (
+    ^ SInteger for: anInteger
+  )
+
+  newDouble: aDouble = (
+    ^ SDouble for: aDouble
+  )
+
+  newString: aString = (
+    ^ SString new: aString
+  )
+
   ----
 
   new = (

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -44,6 +44,14 @@ Universe = (
   falseObject = ( ^ falseObject )
   metaclassClass = ( ^ metaclassClass )
 
+  arrayClass  = ( ^ arrayClass )
+  doubleClass = ( ^ doubleClass )
+  integerClass = ( ^ integerClass )
+  methodClass = ( ^ methodClass )
+  primClass = ( ^ primClass )
+  stringClass = ( ^ stringClass )
+  symbolClass = ( ^ symbolClass )
+
   defaultClassPath = (
     ^ #('.')
   )

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -403,8 +403,8 @@ Universe = (
       result := SourcecodeCompiler compileClass: cpEntry name: name string into: systemClass in: self.
 
       (result notNil and: dumpBytecodes) ifTrue: [
-        Disassembler dump: result somClass.
-        Disassembler dump: result ].
+        Disassembler dump: result somClass in: self.
+        Disassembler dump: result in: self ].
 
       result ifNotNil: [ ^ result ] ].
 
@@ -417,7 +417,7 @@ Universe = (
     "Load the class from a stream and return the loaded class"
     result := SourcecodeCompiler compileClass: stmt into: nil in: self.
     dumpBytecodes ifTrue: [
-      Disassembler dump: result ].
+      Disassembler dump: result in: self ].
     ^ result
   )
 

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -136,9 +136,12 @@ Universe = (
   )
 
   interpret: args = (
-    | remainingArgs |
+    | remainingArgs result |
     remainingArgs := self handleArguments: args.
-    ^ self initializeInterpreter: remainingArgs.
+    result := self initializeInterpreter: remainingArgs.
+    result class == SInteger
+      ifTrue: [ ^ result integer ]
+      ifFalse: [ ^ 1 ]
   )
 
   interpret: className with: selector = (

--- a/SomSom/src/vm/Universe.som
+++ b/SomSom/src/vm/Universe.som
@@ -1,6 +1,8 @@
 Universe = (
   | symbolTable globals classPath dumpBytecodes interpreter
 
+    avoidExit
+
     nilObject
     trueObject
     falseObject
@@ -29,6 +31,12 @@ Universe = (
     globals := Dictionary new.
     interpreter := Interpreter new: self.
     dumpBytecodes := false.
+    avoidExit := false
+  )
+
+  initialize: aBool = (
+    self initialize.
+    avoidExit := aBool
   )
 
   nilObject   = ( ^ nilObject )
@@ -59,7 +67,7 @@ Universe = (
     clazz := self loadClass: (self symbolFor: className).
 
     "Lookup the initialize invokable on the system class"
-    initialize := (clazz somClass: self) lookupInvokable: (self symbolFor: selector).
+    initialize := (clazz somClassIn: self) lookupInvokable: (self symbolFor: selector).
 
     initialize == nil ifTrue: [
       self error: 'Lookup of ' + className + '>>#' + selector + ' failed' ].
@@ -232,6 +240,25 @@ Universe = (
     ^ result
   )
 
+  newFrame: previousFrame with: method with: contextFrame = (
+    | length result |
+    "Compute the maximum number of stack locations (including arguments,
+     locals and extra buffer to support doesNotUnderstand) and set the number
+     of indexable fields accordingly"
+    length := method numberOfArguments
+        + method numberOfLocals
+        + method maximumNumberOfStackElements + 2.
+
+    result := Frame new: nilObject previous: previousFrame context: contextFrame method: method maxStack: length.
+
+    "Reset the stack pointer and the bytecode index"
+    result resetStackPointer.
+    result bytecodeIndex: 1.
+
+    "Return the freshly allocated frame"
+    ^ result
+  )
+
   newSymbol: aString = (
     | result |
     result := SSymbol new: aString.
@@ -390,6 +417,10 @@ Universe = (
 
   new = (
     ^ super new initialize
+  )
+
+  new: avoidExit = (
+    ^ super new initialize: avoidExit
   )
 
   errorPrint: msg = (

--- a/SomSom/src/vmobjects/SAbstractObject.som
+++ b/SomSom/src/vmobjects/SAbstractObject.som
@@ -1,3 +1,52 @@
 SAbstractObject = (
+  send: selectorString with: arguments in: universe using: interpreter = (
+    | selector invokable |
+    selector := universe symbolFor: selectorString.
 
+    interpreter frame push: self.
+
+    arguments do: [:arg |
+      interpreter frame push: arg ].
+
+    invokable := (self somClassIn: universe) lookupInvokable: selector.
+
+    invokable invoke: interpreter frame using: interpreter
+  )
+
+  sendDoesNotUnderstand: selector in: universe with: interpreter = (
+    | numberOfArguments frame argumentsArray args |
+    '++dnu: ' print.
+    self somClass name string print.
+    '>>#' print.
+    selector string println.
+    numberOfArguments := selector numberOfSignatureArguments.
+
+    frame := interpreter frame.
+    frame printStackTrace.
+
+    "Allocate an array with enough room to hold all arguments
+     except for the receiver, which is passed implicitly, as receiver of #dnu."
+    argumentsArray := universe newArray: numberOfArguments - 1.
+
+    "Remove all arguments and put them in the freshly allocated array"
+    numberOfArguments - 1 downTo: 1 do: [:i |
+      argumentsArray indexableField: i put: frame pop ].
+
+    frame pop. "pop receiver"
+
+    args := Array with: selector with: argumentsArray.
+    self send: 'doesNotUnderstand:arguments:' with: args in: universe using: interpreter
+  )
+
+  sendUnknownGlobal: globalName in: universe using: interpreter = (
+    | arguments |
+    arguments := Array with: globalName.
+    self send: 'unknownGlobal:' with: arguments in: universe using: interpreter
+  )
+
+  sendEscapedBlock: block in: universe using: interpreter = (
+    | arguments |
+    arguments := Array with: block.
+    self send: 'escapedBlock:' with: arguments in: universe using: interpreter
+  )
 )

--- a/SomSom/src/vmobjects/SAbstractObject.som
+++ b/SomSom/src/vmobjects/SAbstractObject.som
@@ -13,7 +13,7 @@ SAbstractObject = (
     invokable invoke: interpreter frame using: interpreter
   )
 
-  sendDoesNotUnderstand: selector in: universe with: interpreter = (
+  sendDoesNotUnderstand: selector in: universe using: interpreter = (
     | numberOfArguments frame argumentsArray args |
     '++dnu: ' print.
     self somClass name string print.

--- a/SomSom/src/vmobjects/SAbstractObject.som
+++ b/SomSom/src/vmobjects/SAbstractObject.som
@@ -1,0 +1,3 @@
+SAbstractObject = (
+
+)

--- a/SomSom/src/vmobjects/SAbstractObject.som
+++ b/SomSom/src/vmobjects/SAbstractObject.som
@@ -16,7 +16,7 @@ SAbstractObject = (
   sendDoesNotUnderstand: selector in: universe using: interpreter = (
     | numberOfArguments frame argumentsArray args |
     '++dnu: ' print.
-    self somClass name string print.
+    (self somClassIn: universe) name string print.
     '>>#' print.
     selector string println.
     numberOfArguments := selector numberOfSignatureArguments.

--- a/SomSom/src/vmobjects/SAbstractObject.som
+++ b/SomSom/src/vmobjects/SAbstractObject.som
@@ -15,10 +15,6 @@ SAbstractObject = (
 
   sendDoesNotUnderstand: selector in: universe using: interpreter = (
     | numberOfArguments frame argumentsArray args |
-    '++dnu: ' print.
-    (self somClassIn: universe) name string print.
-    '>>#' print.
-    selector string println.
     numberOfArguments := selector numberOfSignatureArguments.
 
     frame := interpreter frame.

--- a/SomSom/src/vmobjects/SArray.som
+++ b/SomSom/src/vmobjects/SArray.som
@@ -37,6 +37,15 @@ SArray = SAbstractObject (
       destination indexableField: i put: (indexableFields at: i) ]
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = (
+    | elems |
+    elems := ''.
+    indexableFields do: [:e |
+      elems = '' ifTrue: [elems := e debugString]
+                 ifFalse: [ elems := elems + ', ' + e debugString] ].
+     ^ 'SArray(' + indexableFields length + '; ' + elems + ')' )
+
   ----
 
   new: length with: nilObject = (

--- a/SomSom/src/vmobjects/SArray.som
+++ b/SomSom/src/vmobjects/SArray.som
@@ -1,0 +1,45 @@
+SArray = SAbstractObject (
+  | indexableFields |
+
+  initializeWith: length and: nilObject = (
+    indexableFields := Array new: length withAll: nilObject.
+  )
+
+  somClassIn: universe = (
+    ^ universe arrayClass
+  )
+
+  indexableField: idx = (
+    ^ indexableFields at: idx
+  )
+
+  indexableField: idx put: val = (
+    ^ indexableFields at: idx put: val
+  )
+
+  numberOfIndexableFields = (
+    ^ indexableFields length
+  )
+
+  copyAndExtendWith: value in: universe = (
+    | result newLength |
+    newLength := indexableFields length + 1.
+    result := universe newArray: newLength.
+
+    self copyIndexableFieldsTo: result.
+
+    result indexableField: newLength put: value.
+    ^ result
+  )
+
+  copyIndexableFieldsTo: destination = (
+    indexableFields doIndexes: [:i |
+      destination indexableField: i put: (indexableFields at: i) ]
+  )
+
+  ----
+
+  new: length with: nilObject = (
+    ^ self new initializeWith: length and: nilObject
+  )
+)

--- a/SomSom/src/vmobjects/SBlock.som
+++ b/SomSom/src/vmobjects/SBlock.som
@@ -19,6 +19,9 @@ SBlock = SAbstractObject (
     ^ blockClass
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SBlock(' + method asString + ')' )
+
   ----
 
   new: aSMethod in: aContext with: aBlockClass = (

--- a/SomSom/src/vmobjects/SBlock.som
+++ b/SomSom/src/vmobjects/SBlock.som
@@ -1,0 +1,57 @@
+SBlock = SAbstractObject (
+  | method context blockClass |
+
+  initialize: aSMethod in: aContext with: aBlockClass = (
+    method := aSMethod.
+    context := aContext.
+    blockClass := aBlockClass.
+  )
+
+  method = (
+    ^ method
+  )
+
+  context = (
+    ^ context
+  )
+
+  somClassIn: universe = (
+    ^ blockClass
+  )
+
+  ----
+
+  new: aSMethod in: aContext with: aBlockClass = (
+    ^ self new initialize: aSMethod in: aContext with: aBlockClass
+  )
+
+  evaluationPrimitive: numberOfArguments in: universe = (
+    ^ SPrimitive new: (self computeSignatureString: numberOfArguments)
+                  in: universe
+                with: [:frame :interp |
+        | rcvr context newFrame |
+        "Get the block (the receiver) from the stack"
+        rcvr := frame stackElement: numberOfArguments - 1.
+
+        "Get the context of the block"
+        context := rcvr context.
+
+        "Push a new frame and set its context to be the one specified in
+         the block"
+        newFrame := interp pushNewFrame: rcvr method with: context.
+        newFrame copyArgumentsFrom: frame ]
+  )
+
+  computeSignatureString: numberOfArguments = (
+    | signatureString |
+    signatureString := 'value'.
+    numberOfArguments > 1 ifTrue: [
+      signatureString := signatureString + ':' ].
+
+    "Add extra with: selector elements if necessary"
+    2 to: numberOfArguments - 1 do: [:i |
+        signatureString := signatureString + 'with:' ].
+
+    ^ signatureString
+  )
+)

--- a/SomSom/src/vmobjects/SClass.som
+++ b/SomSom/src/vmobjects/SClass.som
@@ -72,7 +72,7 @@ SClass = SObject (
     "Lookup invokable with given signature in array of instance invokables"
     1 to: instanceInvokables numberOfIndexableFields do: [:i |
       "Get the next invokable in the instance invokable array"
-      invokable := instanceInvokable indexableField: i.
+      invokable := instanceInvokables indexableField: i.
 
       "Return the invokable if the signature matches"
       invokable signature == signature ifTrue: [

--- a/SomSom/src/vmobjects/SClass.som
+++ b/SomSom/src/vmobjects/SClass.som
@@ -1,0 +1,188 @@
+SClass = SObject (
+  | universe
+    superClass
+    name
+    instanceInvokables instanceFields|
+
+  initialize: aUniverse = (
+    universe := aUniverse
+  )
+
+  initialize: numberOfFields in: aUniverse = (
+    super initialize: numberOfFields with: aUniverse nilObject.
+    universe := aUniverse
+  )
+
+  superClass = (
+    ^ superClass
+  )
+
+  superClass: aSClass = (
+    superClass := aSClass
+  )
+
+  hasSuperClass = (
+    ^ superClass ~= universe nilObject
+  )
+
+  name = (
+    ^ name
+  )
+
+  name: aSSymbol = (
+    name := aSSymbol
+  )
+
+  instanceFields = (
+    ^ instanceFields
+  )
+
+  instanceFields: aSArray = (
+    instanceFields := aSArray
+  )
+
+  instanceInvokables = (
+    ^ instanceInvokables
+  )
+
+  instanceInvokables: aSArray = (
+    instanceInvokables := aSArray.
+
+    "Make sure this class is the holder of all invokables in the array"
+    1 to: self numberOfInstanceInvokables do: [:i |
+      (instanceInvokables indexableField: i) holder: self ]
+  )
+
+  numberOfInstanceInvokables = (
+    ^ instanceInvokables numberOfIndexableFields
+  )
+
+  instanceInvokable: idx = (
+    ^ instanceInvokables indexableField: idx
+  )
+
+  instanceInvokable: idx put: aSInvokable = (
+    aSInvokable holder: self.
+    instanceInvokables indexableField: idx put: aSInvokable
+  )
+
+  lookupInvokable: signature = (
+    | invokable |
+
+    "Lookup invokable with given signature in array of instance invokables"
+    1 to: instanceInvokables numberOfIndexableFields do: [:i |
+      "Get the next invokable in the instance invokable array"
+      invokable := instanceInvokable indexableField: i.
+
+      "Return the invokable if the signature matches"
+      invokable signature == signature ifTrue: [
+        ^ invokable ] ].
+
+    "Traverse the super class chain by calling lookup on the super class"
+    self hasSuperClass ifTrue: [
+      invokable := superClass lookupInvokable: signature.
+      invokable ~= nil ifTrue: [
+        ^ invokable ] ].
+
+    "Invokable not found"
+    ^ nil
+  )
+
+  lookupFieldIndex: fieldName = (
+    "Lookup field with given name in array of instance fields"
+
+    self numberOfInstanceFields downTo: 1 do: [:i |
+      "Return the current index if the name matches"
+      fieldName == (self instanceFieldName: i)
+        ifTrue: [ ^ i ] ].
+
+    "Field not found"
+    ^ -1
+  )
+
+  addInstanceInvokable: value = (
+    "Add the given invokable to the array of instance invokables"
+    1 to: self numberOfInstanceInvokables do: [:i |
+      "Get the next invokable in the instance invokable array"
+      | invokable |
+      invokable := self instanceInvokable: i.
+
+      "Replace the invokable with the given one if the signature matches"
+      invokable signature == value signature ifTrue: [
+        self instanceInvokable: i put: value.
+        ^ false ] ].
+
+    "Append the given method to the array of instance methods"
+    instanceInvokables := instanceInvokables copyAndExtendWith: value in: universe.
+    ^ true
+  )
+
+  addInstancePrimitive: value = (
+    self addInstancePrimitive: value dontWarn: false
+  )
+
+  addInstancePrimitive: value dontWarn: suppressWarning = (
+    ((self addInstanceInvokable: value) and: [suppressWarning not]) ifTrue: [
+      Universe print: 'Warning: Primitive ' + value signature string.
+      Universe println: ' is not in class definition for class ' + name string ]
+  )
+
+  instanceFieldName: index = (
+    "Get the name of the instance field with the given index"
+    index > self getNumberOfSuperInstanceFields
+      ifTrue: [
+        | idx |
+        "Adjust the index to account for fields defined in the super class"
+        idx := index - self numberOfSuperInstanceFields.
+
+        "Return the symbol representing the instance fields name"
+        ^ instanceFields indexableField: idx ]
+      ifFalse: [
+        "Ask the super class to return the name of the instance field"
+        ^ superClass instanceFieldName: index ]
+  )
+
+  numberOfInstanceFields = (
+    "Get the total number of instance fields in this class"
+    ^ instanceFields numberOfIndexableFields + self numberOfSuperInstanceFields
+  )
+
+  numberOfSuperInstanceFields = (
+    self hasSuperClass
+      ifTrue: [ ^ self superClass numberOfInstanceFields ]
+      ifFalse: [ ^ 0 ]
+  )
+
+  hasPrimitives = (
+    "Lookup invokable with given signature in array of instance invokables"
+    1 to: self numberOfInstanceInvokables do: [:i |
+      "Get the next invokable in the instance invokable array"
+      (self instanceInvokable: i) isPrimitive
+        ifTrue: [ ^ true ] ].
+    ^ false
+  )
+
+  loadPrimitives = (
+    | className primsClass |
+    className := (name string + 'Primitives') asSymbol.
+
+    "Try loading the primitives"
+
+    primsClass := system load: className.
+    primsClass ~= nil
+      ifTrue: [
+        (primsClass new: universe) installPrimitivesIn: self ]
+      ifFalse: [
+        Universe println: 'Primitives class ' + className + ' not found' ]
+  )
+
+  ----
+
+  new: universe = (
+    ^ self new initialize: universe
+  )
+
+  new: numberOfFields in: universe = (
+    ^ self new initialize: numberOfFields in: universe
+  )
+)

--- a/SomSom/src/vmobjects/SClass.som
+++ b/SomSom/src/vmobjects/SClass.som
@@ -176,6 +176,10 @@ SClass = SObject (
         Universe println: 'Primitives class ' + className + ' not found' ]
   )
 
+
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SClass(' + name string + ')' )
+
   ----
 
   new: universe = (

--- a/SomSom/src/vmobjects/SClass.som
+++ b/SomSom/src/vmobjects/SClass.som
@@ -122,6 +122,7 @@ SClass = SObject (
   )
 
   addInstancePrimitive: value dontWarn: suppressWarning = (
+    value holder: self.
     ((self addInstanceInvokable: value) and: [suppressWarning not]) ifTrue: [
       Universe print: 'Warning: Primitive ' + value signature string.
       Universe println: ' is not in class definition for class ' + name string ]

--- a/SomSom/src/vmobjects/SDouble.som
+++ b/SomSom/src/vmobjects/SDouble.som
@@ -1,0 +1,13 @@
+SDouble = SAbstractObject (
+  | value |
+
+  initialize: aDouble = (
+    ^ value
+  )
+
+  ----
+
+  for: aDouble = (
+    ^ self new initialize: aDouble
+  )
+)

--- a/SomSom/src/vmobjects/SDouble.som
+++ b/SomSom/src/vmobjects/SDouble.som
@@ -11,6 +11,9 @@ SDouble = SAbstractObject (
     ^ universe doubleClass
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SDouble(' + value asString + ')' )
+
   ----
 
   for: aDouble = (

--- a/SomSom/src/vmobjects/SDouble.som
+++ b/SomSom/src/vmobjects/SDouble.som
@@ -2,7 +2,13 @@ SDouble = SAbstractObject (
   | value |
 
   initialize: aDouble = (
-    ^ value
+    value := aDouble
+  )
+
+  double = ( ^ value )
+
+  somClassIn: universe = (
+    ^ universe doubleClass
   )
 
   ----

--- a/SomSom/src/vmobjects/SInteger.som
+++ b/SomSom/src/vmobjects/SInteger.som
@@ -2,7 +2,13 @@ SInteger = SAbstractObject (
   | value |
 
   initialize: anInteger = (
-    ^ value
+    value := anInteger
+  )
+
+  integer = ( ^ value )
+
+  somClassIn: universe = (
+    ^ universe integerClass
   )
 
   ----

--- a/SomSom/src/vmobjects/SInteger.som
+++ b/SomSom/src/vmobjects/SInteger.som
@@ -1,0 +1,14 @@
+SInteger = SAbstractObject (
+  | value |
+
+  initialize: anInteger = (
+    ^ value
+  )
+
+  ----
+
+  "TODO: see whether it makes sense to have a cache"
+  for: anInteger = (
+    ^ self new initialize: anInteger
+  )
+)

--- a/SomSom/src/vmobjects/SInteger.som
+++ b/SomSom/src/vmobjects/SInteger.som
@@ -11,6 +11,9 @@ SInteger = SAbstractObject (
     ^ universe integerClass
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SInteger(' + value asString + ')' )
+
   ----
 
   "TODO: see whether it makes sense to have a cache"

--- a/SomSom/src/vmobjects/SMethod.som
+++ b/SomSom/src/vmobjects/SMethod.som
@@ -1,0 +1,84 @@
+SMethod = SAbstractObject (
+  | signature
+    holder
+    bytecodes literals
+    numberOfLocals maximumNumberOfStackElements |
+
+  initializeWith: aSSymbol bc: bcArray literals: literalsArray numLocals: numLocals maxStack: maxStack = (
+    signature := aSSymbol.
+    bytecodes := bcArray.
+    literals := literalsArray.
+    numberOfLocals := numLocals.
+    maximumNumberOfStackElements := maxStack.
+  )
+
+  isPrimitive = (
+    ^ false
+  )
+
+  numberOfLocals = (
+    ^ numberOfLocals
+  )
+
+  maximumNumberOfStackElements = (
+    ^ maximumNumberOfStackElements
+  )
+
+  signature = (
+    ^ signature
+  )
+
+  holder = (
+    ^ holder
+  )
+
+  holder: value = (
+    holder := value.
+
+    literals == nil ifTrue: [ ^ self ].
+
+    "Make sure all nested invokables have the same holder"
+    literals do: [:l |
+      (l class == SMethod or: [l class == SPrimitive]) ifTrue: [
+        l holder: value ] ]
+  )
+
+  constant: bytecodeIndex = (
+    "Get the constant associated to a given bytecode index"
+    ^ literals at: (bytecodes at: bytecodeIndex + 1)
+  )
+
+  numberOfArguments = (
+    "Get the number of arguments of this method"
+    ^ signature numberOfSignatureArguments
+  )
+
+  numberOfBytecodes = (
+    "Get the number of bytecodes in this method"
+    ^ bytecodes length
+  )
+
+  bytecode: index = (
+    "Get the bytecode at the given index"
+    ^ bytecodes at: index
+  )
+
+  invoke: frame using: interpreter = (
+    | newFrame |
+    "Allocate and push a new frame on the interpreter stack"
+    newFrame := interpreter pushNewFrame: self.
+    newFrame copyArgumentsFrom: frame
+  )
+
+  somClassIn: universe = (
+    ^ universe methodClass
+  )
+
+  ----
+
+  new: aSSymbol bc: bcArray literals: literalsArray numLocals: numLocals maxStack: maxStack = (
+    ^ self new
+        initializeWith: aSSymbol bc: bcArray literals: literalsArray numLocals: numLocals maxStack: maxStack
+  )
+
+)

--- a/SomSom/src/vmobjects/SMethod.som
+++ b/SomSom/src/vmobjects/SMethod.som
@@ -74,6 +74,9 @@ SMethod = SAbstractObject (
     ^ universe methodClass
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SMethod(' + holder name + '>>#' + signature string + ')' )
+
   ----
 
   new: aSSymbol bc: bcArray literals: literalsArray numLocals: numLocals maxStack: maxStack = (

--- a/SomSom/src/vmobjects/SObject.som
+++ b/SomSom/src/vmobjects/SObject.som
@@ -42,6 +42,9 @@ SObject = SAbstractObject (
     fields at: index put: value
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SObject(' + clazz name string + ')' )
+
   ----
 
   new: numberOfFields with: nilObject = (

--- a/SomSom/src/vmobjects/SObject.som
+++ b/SomSom/src/vmobjects/SObject.som
@@ -1,0 +1,50 @@
+SObject = SAbstractObject (
+  | fields clazz |
+
+  initialize: numberOfFields with: nilObject = (
+    fields := Array new: numberOfFields withAll: nilObject
+  )
+
+  somClass = (
+    ^ clazz
+  )
+
+  somClass: aSClass = (
+    clazz := aSClass
+  )
+
+  somClassIn: universe = (
+    ^ clazz
+  )
+
+  fieldName: index = (
+    "Get the name of the field with the given index"
+    ^ somClass instanceFieldName: index
+  )
+
+  fieldIndex: name = (
+    "Get the index for the field with the given name"
+    ^ somClass lookupFieldIndex: name
+  )
+
+  numberOfFields = (
+    "Get the number of fields in this object"
+    ^ fields length
+  )
+
+  field: index = (
+    "Get the field with the given index"
+    ^ fields at: index
+  )
+
+  field: index put: value = (
+    "Set the field with the given index to the given value"
+    fields at: index put: value
+  )
+
+  ----
+
+  new: numberOfFields with: nilObject = (
+    ^ self new initialize: numberOfFields with: nilObject
+  )
+)

--- a/SomSom/src/vmobjects/SPrimitive.som
+++ b/SomSom/src/vmobjects/SPrimitive.som
@@ -1,0 +1,60 @@
+SPrimitive = SAbstractObject (
+  | signature holder isEmpty operation |
+
+  initialize: aSSymbol with: aBlock = (
+    signature := aSSymbol.
+    isEmpty := false.
+    operation := aBlock.
+  )
+
+  initializeEmpty: aSSymbol in: universe = (
+    signature := aSSymbol.
+    isEmpty := true.
+    operation := [:frame :interp |
+      | receiver msg |
+      signature numberOfSignatureArguments timesRepeat: [
+        receiver := frame pop ].
+      msg := 'Undefined primitive ' + (receiver somClassIn: universe) name string +
+        '>>#' + signature string + ' called'.
+      self send: 'error:' with: (Array with: receiver with: (universe newString: msg))
+           in: universe using: interp ].
+  )
+
+  isPrimitive = ( ^ true )
+
+  signature = (
+    ^ signature
+  )
+
+  holder = (
+    ^ holder
+  )
+
+  holder: aSClass = (
+    holder := aSClass
+  )
+
+  isEmpty = (
+    ^ isEmpty
+  )
+
+  invoke: frame using: interp = (
+    ^ operation value: frame with: interp
+  )
+
+  somClassIn: universe = (
+    ^ universe primClass
+  )
+
+  ----
+
+  new: signatureString in: universe with: aBlock = (
+    ^ self new initialize: (universe symbolFor: signatureString)
+               with: aBlock
+  )
+
+  emptyPrimitive: signatureString in: universe = (
+    ^ self new initializeEmpty: (universe symbolFor: signatureString)
+               in: universe
+  )
+)

--- a/SomSom/src/vmobjects/SPrimitive.som
+++ b/SomSom/src/vmobjects/SPrimitive.som
@@ -46,6 +46,9 @@ SPrimitive = SAbstractObject (
     ^ universe primClass
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SPrimitive(' + holder name string + '>>#' + signature string + ')' )
+
   ----
 
   new: signatureString in: universe with: aBlock = (

--- a/SomSom/src/vmobjects/SString.som
+++ b/SomSom/src/vmobjects/SString.som
@@ -7,6 +7,10 @@ SString = SAbstractObject (
 
   string = ( ^ string )
 
+  somClassIn: universe = (
+    ^ universe stringClass
+  )
+
   ----
 
   new: aString = (

--- a/SomSom/src/vmobjects/SString.som
+++ b/SomSom/src/vmobjects/SString.som
@@ -11,6 +11,9 @@ SString = SAbstractObject (
     ^ universe stringClass
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SString(' + string + ')' )
+
   ----
 
   new: aString = (

--- a/SomSom/src/vmobjects/SString.som
+++ b/SomSom/src/vmobjects/SString.som
@@ -1,0 +1,3 @@
+SString = SAbstractObject (
+
+)

--- a/SomSom/src/vmobjects/SString.som
+++ b/SomSom/src/vmobjects/SString.som
@@ -1,3 +1,9 @@
 SString = SAbstractObject (
+  | string |
 
+  initializeWith: aString = (
+    string := aString.
+  )
+
+  string = ( ^ string )
 )

--- a/SomSom/src/vmobjects/SString.som
+++ b/SomSom/src/vmobjects/SString.som
@@ -6,4 +6,10 @@ SString = SAbstractObject (
   )
 
   string = ( ^ string )
+
+  ----
+
+  new: aString = (
+    ^ self new initializeWith: aString
+  )
 )

--- a/SomSom/src/vmobjects/SSymbol.som
+++ b/SomSom/src/vmobjects/SSymbol.som
@@ -1,0 +1,3 @@
+SSymbol = SString (
+
+)

--- a/SomSom/src/vmobjects/SSymbol.som
+++ b/SomSom/src/vmobjects/SSymbol.som
@@ -33,6 +33,9 @@ SSymbol = SString (
     ^ universe symbolClass
   )
 
+  "For using in debugging tools such as the Diassembler"
+  debugString = ( ^ 'SSymbol(' + string + ')' )
+
   ----
 
   new: aString = (

--- a/SomSom/src/vmobjects/SSymbol.som
+++ b/SomSom/src/vmobjects/SSymbol.som
@@ -25,6 +25,14 @@ SSymbol = SString (
     ^ true
   )
 
+  numberOfSignatureArguments = (
+    ^ numSignatureArguments
+  )
+
+  somClassIn: universe = (
+    ^ universe symbolClass
+  )
+
   ----
 
   new: aString = (

--- a/SomSom/src/vmobjects/SSymbol.som
+++ b/SomSom/src/vmobjects/SSymbol.som
@@ -1,3 +1,33 @@
 SSymbol = SString (
+  | numSignatureArguments |
 
+  initializeWith: aString = (
+    super initializeWith: aString.
+    numSignatureArguments := self determineNumberOfArguments
+  )
+
+  determineNumberOfArguments = (
+    | numColons |
+    self isBinarySignature ifTrue: [ ^ 2 ].
+
+    numColons := 0.
+
+    1 to: string length do: [:i |
+      ':' = (string charAt: i) ifTrue: [
+        numColons := numColons + 1 ] ].
+    ^ numColons + 1
+  )
+
+  isBinarySignature = (
+    1 to: string length do: [:i |
+      (Lexer isOperator: (string charAt: i))
+        ifFalse: [ ^ false ] ].
+    ^ true
+  )
+
+  ----
+
+  new: aString = (
+    ^ self new initializeWith: aString
+  )
 )

--- a/SomSom/tests/BasicInterpreterTests.som
+++ b/SomSom/tests/BasicInterpreterTests.som
@@ -23,10 +23,6 @@ BasicInterpreterTests = TestCase (
 
     actualResult := u interpret: testClass with: testSel.
 
-    'TTT: ' print.
-    actualResult println.
-    (actualResult somClassIn: u) name string println.
-
     self assertExpectedEqualsSOMValue: actualResult.
   )
 

--- a/SomSom/tests/BasicInterpreterTests.som
+++ b/SomSom/tests/BasicInterpreterTests.som
@@ -112,7 +112,7 @@ BasicInterpreterTests = TestCase (
     self c: 'CompilerSimplification'  t: 'testSetField'        e: 'foo' t: SSymbol.
     self c: 'CompilerSimplification'  t: 'testGetField'        e: 40 t: SInteger.
 
-    "self c: 'Hash'  t: 'testHash'  e: 444 t: SInteger."
+    self c: 'Hash'  t: 'testHash'  e: 444 t: SInteger.
 
     self c: 'Arrays'  t: 'testEmptyToInts'  e: 3 t: SInteger.
     self c: 'Arrays'  t: 'testPutAllInt'    e: 5 t: SInteger.
@@ -141,7 +141,7 @@ BasicInterpreterTests = TestCase (
 
     self c: 'NonLocalVars'  t: 'testWriteDifferentTypes'   e: 3.75 t: SDouble.
 
-    self c: 'ObjectCreation'  t: 'test'   e: 1000000 t: SInteger.
+    "self c: 'ObjectCreation'  t: 'test'   e: 1000000 t: SInteger."
 
     self c: 'Regressions'  t: 'testSymbolEquality'   e: 1 t: SInteger.
     self c: 'Regressions'  t: 'testSymbolReferenceEquality'   e: 1 t: SInteger.

--- a/SomSom/tests/BasicInterpreterTests.som
+++ b/SomSom/tests/BasicInterpreterTests.som
@@ -90,6 +90,9 @@ BasicInterpreterTests = TestCase (
     self c: 'Blocks'  t: 'testArg2' e: 77 t: SInteger.
     self c: 'Blocks'  t: 'testArgAndLocal'   e: 8 t: SInteger.
     self c: 'Blocks'  t: 'testArgAndContext' e: 8 t: SInteger.
+    self c: 'Blocks'  t: 'testEmptyZeroArg'  e: 1 t: SInteger.
+    self c: 'Blocks'  t: 'testEmptyOneArg'   e: 1 t: SInteger.
+    self c: 'Blocks'  t: 'testEmptyTwoArg'   e: 1 t: SInteger.
 
     self c: 'Return'  t: 'testReturnSelf' e: 'Return' t: SClass.
     self c: 'Return'  t: 'testReturnSelfImplicitly' e: 'Return' t: SClass.
@@ -99,6 +102,11 @@ BasicInterpreterTests = TestCase (
     self c: 'IfTrueIfFalse'  t: 'test'  e: 42 t: SInteger.
     self c: 'IfTrueIfFalse'  t: 'test2' e: 33 t: SInteger.
     self c: 'IfTrueIfFalse'  t: 'test3' e:  4 t: SInteger.
+
+    self c: 'IfTrueIfFalse'  t: 'testIfTrueTrueResult'   e: 'Integer' t: SClass.
+    self c: 'IfTrueIfFalse'  t: 'testIfTrueFalseResult'  e: 'Nil'     t: SClass.
+    self c: 'IfTrueIfFalse'  t: 'testIfFalseTrueResult'  e: 'Nil'     t: SClass.
+    self c: 'IfTrueIfFalse'  t: 'testIfFalseFalseResult' e: 'Integer' t: SClass.
   )
 
   setupBasicTest2 = (
@@ -125,8 +133,14 @@ BasicInterpreterTests = TestCase (
     self c: 'BlockInlining'  t: 'testOneLevelInliningWithLocalShadowTrue'   e: 2 t: SInteger.
     self c: 'BlockInlining'  t: 'testOneLevelInliningWithLocalShadowFalse'   e: 1 t: SInteger.
 
-    self c: 'BlockInlining'  t: 'testBlockNestedInIfTrue'   e: 2 t: SInteger.
-    self c: 'BlockInlining'  t: 'testBlockNestedInIfFalse'   e: 42 t: SInteger.
+    self c: 'BlockInlining'  t: 'testShadowDoesntStoreWrongLocal' e: 33 t: SInteger.
+    self c: 'BlockInlining'  t: 'testShadowDoesntReadUnrelated'   e: 'Nil' t: SClass.
+
+    self c: 'BlockInlining'  t: 'testBlockNestedInIfTrue'   e: 2  t: SInteger.
+    self c: 'BlockInlining'  t: 'testBlockNestedInIfFalse'  e: 42 t: SInteger.
+
+    self c: 'BlockInlining'  t: 'testStackDisciplineTrue'   e: 1 t: SInteger.
+    self c: 'BlockInlining'  t: 'testStackDisciplineFalse'  e: 2 t: SInteger.
 
     self c: 'BlockInlining'  t: 'testDeepNestedInlinedIfTrue'   e: 3 t: SInteger.
     self c: 'BlockInlining'  t: 'testDeepNestedInlinedIfFalse'   e: 42 t: SInteger.
@@ -143,10 +157,14 @@ BasicInterpreterTests = TestCase (
 
     "self c: 'ObjectCreation'  t: 'test'   e: 1000000 t: SInteger."
 
-    self c: 'Regressions'  t: 'testSymbolEquality'   e: 1 t: SInteger.
+    self c: 'Regressions'  t: 'testSymbolEquality'            e: 1 t: SInteger.
     self c: 'Regressions'  t: 'testSymbolReferenceEquality'   e: 1 t: SInteger.
+    self c: 'Regressions'  t: 'testUninitializedLocal'        e: 1 t: SInteger.
+    self c: 'Regressions'  t: 'testUninitializedLocalInBlock' e: 1 t: SInteger.
 
-    self c: 'NumberOfTests'  t: 'numberOfTests'   e: 51 t: SInteger.
+    self c: 'BinaryOperation'  t: 'test' e: 3 + 8 t: SInteger.
+
+    self c: 'NumberOfTests'  t: 'numberOfTests' e: 65 t: SInteger.
   )
 
   c: className t: testName e: value t: resultClass = (

--- a/SomSom/tests/BasicInterpreterTests.som
+++ b/SomSom/tests/BasicInterpreterTests.som
@@ -1,0 +1,59 @@
+BasicInterpreterTests = TestCase (
+  | testClass testSelector
+    expectedResult resultType |
+
+  testBasicInterpreter = (
+    self c: 'MethodCall'  t: 'test' e: 42 t: SInteger.
+    self c: 'MethodCall'  t: 'test2' e: 42 t: SInteger.
+
+    self c: 'NonLocalReturn'  t: 'test1' e: 42 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test2' e: 43 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test3' e:  3 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test4' e: 42 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test5' e: 22 t: SInteger.
+  )
+
+  c: className t: testName e: value t: resultClass = (
+    testClass := className.
+    testSelector := testName.
+    expectedResult := value.
+    resultType := resultClass.
+
+    self doBasicInterpreterBehavior.
+  )
+
+  doBasicInterpreterBehavior = (
+    | u actualResult |
+    u := Universe new: true.
+    u setupClassPath: 'Smalltalk:TestSuite/BasicInterpreterTests'.
+
+    actualResult := u interpret: testClass with: testSelector.
+
+    'TTT: ' print.
+    actualResult println.
+    (actualResult somClassIn: u) name string println.
+
+    self assertExpectedEqualsSOMValue: actualResult.
+  )
+
+  assertExpectedEqualsSOMValue: actualResult = (
+    resultType == SInteger ifTrue: [
+      self assert: expectedResult equals: actualResult integer.
+      ^ self ].
+
+    resultType == SDouble ifTrue: [
+      "TODO: allow for small errors/inaccuracies"
+      self assert: expectedResult equals: actualResult integer.
+      ^ self ].
+
+    resultType == SClass ifTrue: [
+      self assert: expectedResult equals: actualResult name string.
+      ^ self ].
+
+    resultType == SSymbol ifTrue: [
+      self assert: expectedResult equals: actualResult string.
+      ^ self ].
+
+    self signalFailure: 'resultType not currently supported: ' + resultType name string
+  )
+)

--- a/SomSom/tests/BasicInterpreterTests.som
+++ b/SomSom/tests/BasicInterpreterTests.som
@@ -1,23 +1,17 @@
 BasicInterpreterTests = TestCase (
-  | testClass testSelector
+  | testClass testSel
     expectedResult resultType |
 
   testBasicInterpreter = (
-    self c: 'MethodCall'  t: 'test' e: 42 t: SInteger.
-    self c: 'MethodCall'  t: 'test2' e: 42 t: SInteger.
+    | arr |
+    arr := BasicInterpreterTests nextTest.
 
-    self c: 'NonLocalReturn'  t: 'test1' e: 42 t: SInteger.
-    self c: 'NonLocalReturn'  t: 'test2' e: 43 t: SInteger.
-    self c: 'NonLocalReturn'  t: 'test3' e:  3 t: SInteger.
-    self c: 'NonLocalReturn'  t: 'test4' e: 42 t: SInteger.
-    self c: 'NonLocalReturn'  t: 'test5' e: 22 t: SInteger.
-  )
+    testClass := arr at: 1.
+    testSel := arr at: 2.
+    expectedResult := arr at: 3.
+    resultType := arr at: 4.
 
-  c: className t: testName e: value t: resultClass = (
-    testClass := className.
-    testSelector := testName.
-    expectedResult := value.
-    resultType := resultClass.
+    testSelector := '  ' + testClass + '>>#' + testSel.
 
     self doBasicInterpreterBehavior.
   )
@@ -27,7 +21,7 @@ BasicInterpreterTests = TestCase (
     u := Universe new: true.
     u setupClassPath: 'Smalltalk:TestSuite/BasicInterpreterTests'.
 
-    actualResult := u interpret: testClass with: testSelector.
+    actualResult := u interpret: testClass with: testSel.
 
     'TTT: ' print.
     actualResult println.
@@ -37,13 +31,17 @@ BasicInterpreterTests = TestCase (
   )
 
   assertExpectedEqualsSOMValue: actualResult = (
+    resultType ~= actualResult class ifTrue: [
+      self signalFailure: 'Unexpected result type: ' + actualResult debugString.
+      ^ self ].
+
     resultType == SInteger ifTrue: [
       self assert: expectedResult equals: actualResult integer.
       ^ self ].
 
     resultType == SDouble ifTrue: [
       "TODO: allow for small errors/inaccuracies"
-      self assert: expectedResult equals: actualResult integer.
+      self assert: expectedResult equals: actualResult double.
       ^ self ].
 
     resultType == SClass ifTrue: [
@@ -55,5 +53,114 @@ BasicInterpreterTests = TestCase (
       ^ self ].
 
     self signalFailure: 'resultType not currently supported: ' + resultType name string
+  )
+
+  ----
+
+  | basicTests next |
+
+  tests = (
+    | tests |
+    next := 1.
+    basicTests := Vector new.
+    tests := Vector new.
+
+    self setupBasicTest.
+    self setupBasicTest2.
+
+    basicTests size timesRepeat: [
+      tests append: (self for: #testBasicInterpreter) ].
+    ^ tests
+  )
+
+  nextTest = (
+    | test |
+    test := basicTests at: next.
+    next := next + 1.
+    ^ test
+  )
+
+  setupBasicTest = (
+    self c: 'MethodCall'  t: 'test' e: 42 t: SInteger.
+    self c: 'MethodCall'  t: 'test2' e: 42 t: SInteger.
+
+    self c: 'NonLocalReturn'  t: 'test1' e: 42 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test2' e: 43 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test3' e:  3 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test4' e: 42 t: SInteger.
+    self c: 'NonLocalReturn'  t: 'test5' e: 22 t: SInteger.
+
+    self c: 'Blocks'  t: 'testArg1' e: 42 t: SInteger.
+    self c: 'Blocks'  t: 'testArg2' e: 77 t: SInteger.
+    self c: 'Blocks'  t: 'testArgAndLocal'   e: 8 t: SInteger.
+    self c: 'Blocks'  t: 'testArgAndContext' e: 8 t: SInteger.
+
+    self c: 'Return'  t: 'testReturnSelf' e: 'Return' t: SClass.
+    self c: 'Return'  t: 'testReturnSelfImplicitly' e: 'Return' t: SClass.
+    self c: 'Return'  t: 'testNoReturnReturnsSelf' e: 'Return' t: SClass.
+    self c: 'Return'  t: 'testBlockReturnsImplicitlyLastValue' e: 4 t: SInteger.
+
+    self c: 'IfTrueIfFalse'  t: 'test'  e: 42 t: SInteger.
+    self c: 'IfTrueIfFalse'  t: 'test2' e: 33 t: SInteger.
+    self c: 'IfTrueIfFalse'  t: 'test3' e:  4 t: SInteger.
+  )
+
+  setupBasicTest2 = (
+    self c: 'CompilerSimplification'  t: 'testReturnConstantSymbol' e:  'constant' t: SSymbol.
+    self c: 'CompilerSimplification'  t: 'testReturnConstantInt' e: 42 t: SInteger.
+    self c: 'CompilerSimplification'  t: 'testReturnSelf' e: 'CompilerSimplification' t: SClass.
+    self c: 'CompilerSimplification'  t: 'testReturnSelfImplicitly' e: 'CompilerSimplification' t: SClass.
+
+    self c: 'CompilerSimplification'  t: 'testReturnArgumentN' e: 55 t: SInteger.
+    self c: 'CompilerSimplification'  t: 'testReturnArgumentA' e: 44 t: SInteger.
+    self c: 'CompilerSimplification'  t: 'testSetField'        e: 'foo' t: SSymbol.
+    self c: 'CompilerSimplification'  t: 'testGetField'        e: 40 t: SInteger.
+
+    "self c: 'Hash'  t: 'testHash'  e: 444 t: SInteger."
+
+    self c: 'Arrays'  t: 'testEmptyToInts'  e: 3 t: SInteger.
+    self c: 'Arrays'  t: 'testPutAllInt'    e: 5 t: SInteger.
+    self c: 'Arrays'  t: 'testPutAllNil'    e: 'Nil' t: SClass.
+    self c: 'Arrays'  t: 'testPutAllBlock'  e: 3 t: SInteger.
+    self c: 'Arrays'  t: 'testNewWithAll'   e: 1 t: SInteger.
+
+    self c: 'BlockInlining'  t: 'testNoInlining'   e: 1 t: SInteger.
+    self c: 'BlockInlining'  t: 'testOneLevelInlining'   e: 1 t: SInteger.
+    self c: 'BlockInlining'  t: 'testOneLevelInliningWithLocalShadowTrue'   e: 2 t: SInteger.
+    self c: 'BlockInlining'  t: 'testOneLevelInliningWithLocalShadowFalse'   e: 1 t: SInteger.
+
+    self c: 'BlockInlining'  t: 'testBlockNestedInIfTrue'   e: 2 t: SInteger.
+    self c: 'BlockInlining'  t: 'testBlockNestedInIfFalse'   e: 42 t: SInteger.
+
+    self c: 'BlockInlining'  t: 'testDeepNestedInlinedIfTrue'   e: 3 t: SInteger.
+    self c: 'BlockInlining'  t: 'testDeepNestedInlinedIfFalse'   e: 42 t: SInteger.
+
+    self c: 'BlockInlining'  t: 'testDeepNestedBlocksInInlinedIfTrue'   e: 5 t: SInteger.
+    self c: 'BlockInlining'  t: 'testDeepNestedBlocksInInlinedIfFalse'   e: 43 t: SInteger.
+
+    self c: 'BlockInlining'  t: 'testDeepDeepNestedTrue'   e: 9 t: SInteger.
+    self c: 'BlockInlining'  t: 'testDeepDeepNestedFalse'   e: 43 t: SInteger.
+
+    self c: 'BlockInlining'  t: 'testToDoNestDoNestIfTrue'   e: 2 t: SInteger.
+
+    self c: 'NonLocalVars'  t: 'testWriteDifferentTypes'   e: 3.75 t: SDouble.
+
+    self c: 'ObjectCreation'  t: 'test'   e: 1000000 t: SInteger.
+
+    self c: 'Regressions'  t: 'testSymbolEquality'   e: 1 t: SInteger.
+    self c: 'Regressions'  t: 'testSymbolReferenceEquality'   e: 1 t: SInteger.
+
+    self c: 'NumberOfTests'  t: 'numberOfTests'   e: 51 t: SInteger.
+  )
+
+  c: className t: testName e: value t: resultClass = (
+    | arr |
+    arr := Array new: 4.
+    arr at: 1 put: className.
+    arr at: 2 put: testName.
+    arr at: 3 put: value.
+    arr at: 4 put: resultClass.
+
+    basicTests append: arr.
   )
 )

--- a/SomSom/tests/FrameTests.som
+++ b/SomSom/tests/FrameTests.som
@@ -1,0 +1,118 @@
+FrameTests = TestCase (
+  | u a b c d e f g h |
+
+  initialize = (
+    u := Universe new: true.
+    u setupClassPath: 'Smalltalk:TestSuite/BasicInterpreterTests'.
+    u initializeObjectSystem.
+
+    a := SSymbol new: 'a'.
+    b := SSymbol new: 'b'.
+    c := SSymbol new: 'c'.
+    d := SSymbol new: 'd'.
+    e := SSymbol new: 'e'.
+    g := SSymbol new: 'g'.
+    h := SSymbol new: 'h'.
+  )
+
+  method: name numLocals: numLocals = (
+    | sym clazz method |
+    sym := SSymbol new: name.
+    clazz := SClass new: u.
+    clazz name: (SSymbol new: 'Holder').
+    method := SMethod new: sym bc: #() literals: #() numLocals: numLocals maxStack: 4.
+    method holder: clazz.
+    ^ method
+  )
+
+  testPushPop = (
+    | f length m |
+    m := self method: 'testPushPop' numLocals: 0.
+    length := 4 + m numberOfArguments + m numberOfLocals.
+    f := Frame new: u nilObject previous: nil context: nil method: m maxStack: length.
+    f resetStackPointer.
+
+    f push: a.
+    self assert: 'a' equals: (f stackElement: 0) string.
+    f push: b.
+    self assert: 'b' equals: (f stackElement: 0) string.
+    f push: c.
+    self assert: 'c' equals: (f stackElement: 0) string.
+    f pop.
+    self assert: 'b' equals: (f stackElement: 0) string.
+    f pop.
+    self assert: 'a' equals: (f stackElement: 0) string.
+    f pop.
+  )
+
+  testArgsAndLocal = (
+    | f length m |
+    m := self method: 'testArgsAndLocal' numLocals: 2.
+    length := 4 + m numberOfArguments + m numberOfLocals.
+    f := Frame new: u nilObject previous: nil context: nil method: m maxStack: length.
+    f resetStackPointer.
+
+    f argument: 1 put: a. "rcvr"
+    f argument: 2 put: b. "local 1"
+    f argument: 3 put: c. "local 2"
+    f push: d.
+    f push: e.
+    f push: g.
+    f push: h.
+
+    self assert: 'a' equals: (f argument: 1) string.
+    self assert: 'b' equals: (f local: 1) string.
+    self assert: 'c' equals: (f local: 2) string.
+    self assert: 'h' equals: (f stackElement: 0) string.
+    self assert: 'g' equals: (f stackElement: 1) string.
+    self assert: 'e' equals: (f stackElement: 2) string.
+    self assert: 'd' equals: (f stackElement: 3) string.
+    self assert: 'c' equals: (f stackElement: 4) string.
+  )
+
+  testCopyArgs = (
+    | f length m1 m2 copyF |
+    m1 := self method: 'sourceTest:copy:args:' numLocals: 2.
+    m2 := self method: 'targetTest:copy:args:' numLocals: 2.
+    length := 5 + m1 numberOfArguments + m1 numberOfLocals.
+    f := Frame new: u nilObject previous: nil context: nil method: m1 maxStack: length.
+    f resetStackPointer.
+
+    f local: 1 put: e. "local 1"
+    f local: 2 put: g. "local 2"
+    f push: h. "stack 1"
+    "stuff to be copied"
+    f push: a. "rcvr"
+    f push: b. "arg test:"
+    f push: c. "arg copy:"
+    f push: d. "arg args:"
+
+    copyF := Frame new: u nilObject previous: nil context: nil method: m2 maxStack: length.
+    copyF resetStackPointer.
+    copyF copyArgumentsFrom: f.
+
+    self assert: 'a' equals: (copyF argument: 1) string.
+    self assert: 'b' equals: (copyF argument: 2) string.
+    self assert: 'c' equals: (copyF argument: 3) string.
+    self assert: 'd' equals: (copyF argument: 4) string.
+    self assert: u nilObject is: (copyF local: 1).
+    self assert: u nilObject is: (copyF local: 2).
+    self assert: u nilObject is: (copyF stackElement: 0).
+
+    copyF push: e. "arg args:"
+
+    self assert: 'a' equals: (copyF argument: 1) string.
+    self assert: 'b' equals: (copyF argument: 2) string.
+    self assert: 'c' equals: (copyF argument: 3) string.
+    self assert: 'd' equals: (copyF argument: 4) string.
+    self assert: u nilObject is: (copyF local: 1).
+    self assert: u nilObject is: (copyF local: 2).
+    self assert: 'e' equals: (copyF stackElement: 0) string.
+
+  )
+  ----
+
+  new = (
+    ^ super new initialize
+  )
+)

--- a/SomSom/tests/LexerTests.som
+++ b/SomSom/tests/LexerTests.som
@@ -1,0 +1,176 @@
+LexerTests = TestCase (
+
+  testEmptyClass = (
+    | l |
+    l := Lexer new: 'Foo = ()'.
+
+    self assert: #identifier is: l sym.
+    self assert: 'Foo' equals: l text.
+
+    self assert: #equal is: l sym.
+    self assert: '=' equals: l text.
+
+    self assert: #newTerm is: l sym.
+    self assert: '(' equals: l text.
+
+    self assert: #endTerm is: l sym.
+    self assert: ')' equals: l text.
+
+    self assert: #NONE is: l sym.
+  )
+
+  testKeywordSymbol = (
+    | l |
+    l := Lexer new: '#key:word:'.
+
+    self assert: #pound is: l sym.
+    self assert: '#' equals: l text.
+
+    self assert: #keywordSequence is: l sym.
+    self assert: 'key:word:' equals: l text.
+
+    self assert: #NONE is: l sym.
+  )
+
+  testIntMessage = (
+    | l |
+    l := Lexer new: '314 println'.
+
+    self assert: #integer is: l sym.
+    self assert: '314' equals: l text.
+
+    self assert: #identifier is: l sym.
+    self assert: 'println' equals: l text.
+
+    self assert: #NONE is: l sym.
+  )
+
+  testAssignDouble = (
+    | l |
+    l := Lexer new: 'var := 3.14.'.
+
+    self assert: #identifier is: l sym.
+    self assert: 'var' equals: l text.
+
+    self assert: #assign is: l sym.
+    self assert: ':=' equals: l text.
+
+    self assert: #double is: l sym.
+    self assert: '3.14' equals: l text.
+
+    self assert: #period is: l sym.
+    self assert: '.' equals: l text.
+
+    self assert: #NONE is: l sym.
+  )
+
+  testString = (
+    | l str |
+    str := '\'some string with new\nline\''.
+    l := Lexer new: str.
+
+    self assert: #string is: l sym.
+    self assert: 'some string with new\nline' equals: l text.
+
+    self assert: #NONE is: l sym.
+  )
+
+  testEscapeChars = (
+    | l str |
+    str := '\'\\n\\0\\t\''.
+    l := Lexer new: str.
+
+    self assert: #string is: l sym.
+    self assert: '\n\0\t' equals: l text.
+    self assert: 3 equals: l text length.
+
+    self assert: #NONE is: l sym.
+  )
+
+  testPrimitiveMethod = (
+    | l |
+    l := Lexer new: ' foo: bar = primitive '.
+
+    self assert: #keyword is: l sym.
+    self assert: 'foo:' equals: l text.
+
+    self assert: #identifier is: l sym.
+    self assert: 'bar' equals: l text.
+
+    self assert: #equal is: l sym.
+    self assert: '=' equals: l text.
+
+    self assert: #primitive is: l sym.
+    self assert: 'primitive' equals: l text.
+  )
+
+  testMathBlock = (
+    | l syms |
+    l := Lexer new: '[ 0 ~ 1 & 2 | 3 * 4 / 5 \\ 6 + 7 - 8 > 9 < 10 , 11 @ 12 % 13]'.
+
+    syms := #(#not #and #or #star #div #mod #plus #minus #more #less #comma #at #per).
+
+    self assert: #newBlock is: l sym.
+    self assert: '[' equals: l text.
+
+    0 to: 12 do: [:i |
+      self assert: #integer is: l sym.
+      self assert: i asString equals: l text.
+      self assert: (syms at: i + 1) is: l sym ].
+
+    self assert: #integer is: l sym.
+    self assert: '13' equals: l text.
+
+    self assert: #endBlock is: l sym.
+    self assert: ']' equals: l text.
+  )
+
+  testOperatorSequence = (
+    | l |
+    l := Lexer new: '1 ------ ---- --> 2'.
+
+    self assert: #integer is: l sym.
+    self assert: '1' equals: l text.
+
+    self assert: #separator is: l sym.
+    self assert: '------' equals: l text.
+
+    self assert: #separator is: l sym.
+    self assert: '----' equals: l text.
+
+    self assert: #operatorSequence is: l sym.
+    self assert: '-->' equals: l text.
+
+    self assert: #integer is: l sym.
+    self assert: '2' equals: l text.
+  )
+
+  testBlock = (
+    | l |
+    l := Lexer new: '[:x | ^ 1]'.
+
+    self assert: #newBlock is: l sym.
+    self assert: '[' equals: l text.
+
+    self assert: #colon is: l sym.
+    self assert: ':' equals: l text.
+
+    self assert: #identifier is: l sym.
+    self assert: 'x' equals: l text.
+
+    self assert: #or is: l sym.
+    self assert: '|' equals: l text.
+
+    self assert: #exit is: l sym.
+    self assert: '^' equals: l text.
+
+    self assert: #integer is: l sym.
+    self assert: '1' equals: l text.
+
+    self assert: #endBlock is: l sym.
+    self assert: ']' equals: l text.
+  )
+
+
+  "  Colon, Exit  "
+)

--- a/SomSom/tests/ParserTests.som
+++ b/SomSom/tests/ParserTests.som
@@ -47,7 +47,7 @@ ParserTests = TestCase (
     u := Universe new.
     parser := ParserWithError newWith: 'Foo ()' for: 'Foo.som' in: u.
     cgenc := self parseAndCaptureError: parser.
-    self assert: 'Parsing failed, expected equal but found newTerm (()' equals: cgenc
+    self assert: (cgenc beginsWith: 'Parsing of Foo.som failed, expected equal but found newTerm')
   )
 
   testEmptyClassWithComment = (

--- a/SomSom/tests/ParserTests.som
+++ b/SomSom/tests/ParserTests.som
@@ -1,14 +1,15 @@
 ParserTests = TestCase (
+  | universe |
   testEmptyClass = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = ()' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testSpaceBeforeEmptyClass = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: '
         Foo = ()' for: 'Foo.som' in: u.
     cgenc := parser classdef.
@@ -16,7 +17,7 @@ ParserTests = TestCase (
 
   testCommentBeforeEmptyClass = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: '
       "This is a Foo Class"
       Foo = ()' for: 'Foo.som' in: u.
@@ -25,14 +26,14 @@ ParserTests = TestCase (
 
   testEmptyWithNilSuperClass = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = nil ()' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testEmptyWithObjectSuperClass = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = Object ()' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
@@ -44,7 +45,7 @@ ParserTests = TestCase (
 
   testEmptyClassMissingEqual = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := ParserWithError newWith: 'Foo ()' for: 'Foo.som' in: u.
     cgenc := self parseAndCaptureError: parser.
     self assert: (cgenc beginsWith: 'Parsing of Foo.som failed, expected equal but found newTerm')
@@ -52,49 +53,49 @@ ParserTests = TestCase (
 
   testEmptyClassWithComment = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = ( "comment" )' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testClassWithFields = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = (|a b c|)' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testClassWithUnaryMethod = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = ( m = () )' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testClassWithBinaryMethod = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = ( * o = () )' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testClassWithKeywordMethod = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = ( m: o = () )' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testClassWithKeywordPrimitive = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: 'Foo = ( m: o = primitive )' for: 'Foo.som' in: u.
     cgenc := parser classdef.
   )
 
   testClassWithVariousMethods = (
     | cgenc parser u |
-    u := Universe new.
+    u := self initUniverse.
     parser := Parser newWith: '
     ClassWithVariousMethods = (
       a: o = ( | s n v | )
@@ -149,10 +150,63 @@ ParserTests = TestCase (
 
     files do: [:f |
       | cgenc parser u |
-      u := Universe new.
-      f println.
+      u := self initUniverse.
       parser := Parser load: 'Smalltalk/' + f in: u.
       self deny: parser isNil.
       cgenc := parser classdef ].
+  )
+
+  testTestSuiteFolder = (
+    | files |
+    files := #(
+      'ArrayTest.som'
+      'BlockTest.som'
+      'ClassA.som'
+      'ClassB.som'
+      'ClassC.som'
+      'ClassLoadingTest.som'
+      'ClassStructureTest.som'
+      'ClosureTest.som'
+      'CoercionTest.som'
+      'CompilerReturnTest.som'
+      'DoesNotUnderstandMessage.som'
+      'DoesNotUnderstandTest.som'
+      'DoubleTest.som'
+      'EmptyTest.som'
+      'GlobalTest.som'
+      'HashTest.som'
+      'IntegerTest.som'
+      'PreliminaryTest.som'
+      'ReflectionTest.som'
+      'SelfBlockTest.som'
+      'SetTest.som'
+      'SpecialSelectorsTest.som'
+      'StringTest.som'
+      'SuperTest.som'
+      'SuperTestSuperClass.som'
+      'SymbolTest.som'
+      'SystemTest.som'
+      'TestCase.som'
+      'TestHarness.som'
+      'TestRunner.som'
+      'VectorTest.som'
+    ).
+
+    files do: [:f |
+      | cgenc parser u |
+      u := self initUniverse.
+      parser := Parser load: 'TestSuite/' + f in: u.
+      self deny: parser isNil.
+      cgenc := parser classdef ].
+  )
+
+  initUniverse = (
+    | u |
+    universe ifNil: [
+      u := Universe new.
+      u setupClassPath: 'Smalltalk:TestSuite'.
+      u initializeObjectSystem.
+      universe := u ].
+    ^ universe
   )
 )

--- a/SomSom/tests/ParserTests.som
+++ b/SomSom/tests/ParserTests.som
@@ -135,13 +135,13 @@ ParserTests = TestCase (
       'Hashtable.som'
       'Integer.som'
       'Metaclass.som'
-      "'Method.som'"
+      'Method.som'
       'Nil.som'
-      "'Object.som'"
+      'Object.som'
       'Pair.som'
       'Primitive.som'
       'Set.som'
-      "'String.som'"
+      'String.som'
       'Symbol.som'
       'System.som'
       'True.som'

--- a/SomSom/tests/ParserTests.som
+++ b/SomSom/tests/ParserTests.som
@@ -110,10 +110,10 @@ ParserTests = TestCase (
       i: o = ( super foo )
       j: o = ( (1) )
       k: o = ( [1] )
-      k: o = ( 1 foo: 4 )
-      k: o = ( 1 + 4 )
-      k: o = ( 1 ++ 2 )
-      k: o = ( #(2 3 4 5) )
+      l: o = ( 1 foo: 4 )
+      m: o = ( 1 + 4 )
+      n: o = ( 1 ++ 2 )
+      o: o = ( #(2 3 4 5) )
     )' for: 'ClassWithVariousMethods.som' in: u.
     cgenc := parser classdef.
   )

--- a/SomSom/tests/ParserTests.som
+++ b/SomSom/tests/ParserTests.som
@@ -1,0 +1,8 @@
+ParserTests = TestCase (
+  testEmptyClass = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = nil ()' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+)

--- a/SomSom/tests/ParserTests.som
+++ b/SomSom/tests/ParserTests.som
@@ -117,4 +117,42 @@ ParserTests = TestCase (
     )' for: 'ClassWithVariousMethods.som' in: u.
     cgenc := parser classdef.
   )
+
+  testSmalltalkFolder = (
+    | files |
+    files := #(
+      'Array.som'
+      'Block.som'
+      'Block1.som'
+      'Block2.som'
+      'Block3.som'
+      'Boolean.som'
+      'Class.som'
+      'Dictionary.som'
+      'Double.som'
+      'False.som'
+      'HashEntry.som'
+      'Hashtable.som'
+      'Integer.som'
+      'Metaclass.som'
+      "'Method.som'"
+      'Nil.som'
+      "'Object.som'"
+      'Pair.som'
+      'Primitive.som'
+      'Set.som'
+      "'String.som'"
+      'Symbol.som'
+      'System.som'
+      'True.som'
+      'Vector.som' ).
+
+    files do: [:f |
+      | cgenc parser u |
+      u := Universe new.
+      f println.
+      parser := Parser load: 'Smalltalk/' + f in: u.
+      self deny: parser isNil.
+      cgenc := parser classdef ].
+  )
 )

--- a/SomSom/tests/ParserTests.som
+++ b/SomSom/tests/ParserTests.som
@@ -2,7 +2,119 @@ ParserTests = TestCase (
   testEmptyClass = (
     | cgenc parser u |
     u := Universe new.
+    parser := Parser newWith: 'Foo = ()' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testSpaceBeforeEmptyClass = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: '
+        Foo = ()' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testCommentBeforeEmptyClass = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: '
+      "This is a Foo Class"
+      Foo = ()' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testEmptyWithNilSuperClass = (
+    | cgenc parser u |
+    u := Universe new.
     parser := Parser newWith: 'Foo = nil ()' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testEmptyWithObjectSuperClass = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = Object ()' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  parseAndCaptureError: parser = (
+    parser errorHandler: [:msg | ^ msg ].
+    ^ parser classdef.
+  )
+
+  testEmptyClassMissingEqual = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := ParserWithError newWith: 'Foo ()' for: 'Foo.som' in: u.
+    cgenc := self parseAndCaptureError: parser.
+    self assert: 'Parsing failed, expected equal but found newTerm (()' equals: cgenc
+  )
+
+  testEmptyClassWithComment = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = ( "comment" )' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testClassWithFields = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = (|a b c|)' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testClassWithUnaryMethod = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = ( m = () )' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testClassWithBinaryMethod = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = ( * o = () )' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testClassWithKeywordMethod = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = ( m: o = () )' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testClassWithKeywordPrimitive = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: 'Foo = ( m: o = primitive )' for: 'Foo.som' in: u.
+    cgenc := parser classdef.
+  )
+
+  testClassWithVariousMethods = (
+    | cgenc parser u |
+    u := Universe new.
+    parser := Parser newWith: '
+    ClassWithVariousMethods = (
+      a: o = ( | s n v | )
+      b: o = ( ^ 1 )
+      bn: o = ( ^ -1 )
+      c: o = ( ^ 2.2 )
+      cn: o = ( ^ -2.2 )
+      d: o = ( ^ \'ss\' )
+      e: o = ( ^ #sym )
+      f: o = ( | a | a := a := 2 )
+      g: o = ( o )
+      h: o = ( self foo )
+      i: o = ( super foo )
+      j: o = ( (1) )
+      k: o = ( [1] )
+      k: o = ( 1 foo: 4 )
+      k: o = ( 1 + 4 )
+      k: o = ( 1 ++ 2 )
+      k: o = ( #(2 3 4 5) )
+    )' for: 'ClassWithVariousMethods.som' in: u.
     cgenc := parser classdef.
   )
 )

--- a/SomSom/tests/ParserWithError.som
+++ b/SomSom/tests/ParserWithError.som
@@ -1,0 +1,11 @@
+ParserWithError = Parser (
+  | errorHandler |
+
+  errorHandler: aBlock = (
+    errorHandler := aBlock
+  )
+
+  error: message = (
+    errorHandler value: message
+  )
+)

--- a/SomSom/tests/SomSomTests.som
+++ b/SomSom/tests/SomSomTests.som
@@ -1,6 +1,7 @@
 SomSomTests = TestHarness (
   tests = (
     ^ EmptyTest,
+      FrameTests,
       LexerTests,
       ParserTests
   )

--- a/SomSom/tests/SomSomTests.som
+++ b/SomSom/tests/SomSomTests.som
@@ -1,6 +1,7 @@
 SomSomTests = TestHarness (
   tests = (
     ^ EmptyTest,
-      LexerTests
+      LexerTests,
+      ParserTests
   )
 )

--- a/SomSom/tests/SomSomTests.som
+++ b/SomSom/tests/SomSomTests.som
@@ -1,0 +1,6 @@
+SomSomTests = TestHarness (
+  tests = (
+    ^ EmptyTest,
+      LexerTests
+  )
+)

--- a/SomSom/tests/SomSomTests.som
+++ b/SomSom/tests/SomSomTests.som
@@ -2,8 +2,9 @@ SomSomTests = TestHarness (
   tests = (
     ^ EmptyTest,
       FrameTests,
-      BasicInterpreterTests,
       LexerTests,
-      ParserTests
+      ParserTests,
+      BasicInterpreterTests,
+      SomTests
   )
 )

--- a/SomSom/tests/SomSomTests.som
+++ b/SomSom/tests/SomSomTests.som
@@ -2,6 +2,7 @@ SomSomTests = TestHarness (
   tests = (
     ^ EmptyTest,
       FrameTests,
+      BasicInterpreterTests,
       LexerTests,
       ParserTests
   )

--- a/SomSom/tests/SomTests.som
+++ b/SomSom/tests/SomTests.som
@@ -1,0 +1,45 @@
+SomTests = TestCase (
+
+  testArray          = ( self doTest: 'Array' )
+  testBlock          = ( self doTest: 'Block' )
+  testClassLoading   = ( self doTest: 'ClassLoading' )
+  testClassStructure = ( self doTest: 'ClassStructure' )
+
+  testClosure           = ( self doTest: 'Closure' )
+  testCoercion          = ( self doTest: 'Coercion' )
+  testCompilerReturn    = ( self doTest: 'CompilerReturn' )
+  testDoesNotUnderstand = ( self doTest: 'DoesNotUnderstand' )
+  testDouble            = ( self doTest: 'Double' )
+
+  testEmpty             = ( self doTest: 'Empty' )
+  testGlobal            = ( self doTest: 'Global' )
+  "testHash              = ( self doTest: 'Hash' )"
+  testInteger           = ( self doTest: 'Integer' )
+
+  testPreliminary       = ( self doTest: 'Preliminary' )
+  testReflection        = ( self doTest: 'Reflection' )
+  testSelfBlock         = ( self doTest: 'SelfBlock' )
+  testSpecialSelectorsTest = ( self doTest: 'SpecialSelectorsTest' )
+  testSuper             = ( self doTest: 'Super' )
+
+  testSet                = ( self doTest: 'Set' )
+  testString             = ( self doTest: 'String' )
+  testSymbol             = ( self doTest: 'Symbol' )
+  testSystem             = ( self doTest: 'System' )
+  testVector             = ( self doTest: 'Vector' )
+
+  doTest: testName = (
+    | args u exitCode |
+    args := Array new: 4.
+    args at: 1 put: '-cp'.
+    args at: 2 put: 'Smalltalk'.
+    args at: 3 put: 'TestSuite/TestHarness.som'.
+    args at: 4 put: testName.
+
+    u := Universe new: true.
+
+    exitCode := u interpret: args.
+
+    self assert: 0 equals: exitCode.
+  )
+)

--- a/SomSom/tests/SomTests.som
+++ b/SomSom/tests/SomTests.som
@@ -13,7 +13,7 @@ SomTests = TestCase (
 
   testEmpty             = ( self doTest: 'Empty' )
   testGlobal            = ( self doTest: 'Global' )
-  "testHash              = ( self doTest: 'Hash' )"
+  testHash              = ( self doTest: 'Hash' )
   testInteger           = ( self doTest: 'Integer' )
 
   testPreliminary       = ( self doTest: 'Preliminary' )


### PR DESCRIPTION
This PR implements SOM in SOM.
It's a pretty direct translation of the basic version of the SOM bytecode interpreter with 16 bytecodes.
It is able to execute all tests of the standard SOM test suite.
Though, it's pretty darn slow.

It also runs Hello World and probably some of the benchmarks, but I haven't confirmed this yet, ~~because it's very very slow~~. Oops. I was running multiple levels of interpreters.

To run, it needs the primitives introduced in https://github.com/SOM-st/SOM/pull/67.
It may also need changes to how the command line arguments are handled so that the options are passed to SomSom and not consumed by the host SOM, for example see: https://github.com/smarr/TruffleSOM/commit/7f0f26cbe50e26aba841c2acd7b9fc0258765738

It should also be able to run multiple "storeys" of a tower of interpreters. ~~Though, I haven't tested this recently.~~ Yep. Works. See comment below.

Originally, this started out as a PR just for the lexer:
~~Implement the SOM Lexer in SOM.~~

~~This requires three new primitives and a new string escape code:~~
 - `String>>#isWhiteSpace`
 - `String>>#isLetter`
 - `String>>#isDigit`
 - and the `\0` escape code, which should be pretty standard, but we haven't had need for it before

@sophie-kaleba could you review this please, too?

@ltratt I thought this might be of interest to you. Well, perhaps not quite yet, but, it's also a nice test case for the parser and string support logic.