### PR TITLE
Add test for super semantics in the context of binary messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
 
     - language: java
       dist: trusty
-      env: SOM=TruffleSOM  REPO=TruffleSOM.git  BUILD=ant    SOM="./som -G"
+      env: SOM=TruffleSOM  REPO=TruffleSOM.git  BUILD="ant jar"    SOM="./som -G"
       jdk: [oraclejdk8]
       addons: {apt: {packages: [libc6-dev-i386]}}
 

--- a/TestSuite/SuperTest.som
+++ b/TestSuite/SuperTest.som
@@ -51,17 +51,28 @@ SuperTest = SuperTestSuperClass (
     ^ 10
   )
 
-  testBinaryMessage = (
+  testWithBinaryUnaryMessage = (
     | val |
     record := 0.
     val := super number * super number.
     self assert: 1 equals: val.
   )
 
-  testBinaryUnaryMessage = (
+  testWithBinaryUnaryUnaryMessage = (
     | val |
     record := 0.
     super yourself yourself @ super yourself yourself.
+    self assert: 2002 equals: record.
+  )
+
+  testWithKeywordUnaryUnaryMessage = (
+    | val |
+    record := 0.
+    super key: super yourself yourself key: super yourself yourself.
+    self assert: 2002 equals: record.
+
+    record := 0.
+    self key: super yourself yourself key: super yourself yourself.
     self assert: 2002 equals: record.
   )
 

--- a/TestSuite/SuperTest.som
+++ b/TestSuite/SuperTest.som
@@ -30,6 +30,11 @@ SuperTest = SuperTestSuperClass (
     self assert: 42 equals: self blockGive42.
   )
 
+  yourself = (
+    record := record + 1000.
+    ^ self
+  )
+
   give42 = (
     ^super give42
   )
@@ -40,6 +45,24 @@ SuperTest = SuperTestSuperClass (
 
   something = (
     ^ #sub
+  )
+
+  number = (
+    ^ 10
+  )
+
+  testBinaryMessage = (
+    | val |
+    record := 0.
+    val := super number * super number.
+    self assert: 1 equals: val.
+  )
+
+  testBinaryUnaryMessage = (
+    | val |
+    record := 0.
+    super yourself yourself @ super yourself yourself.
+    self assert: 2002 equals: record.
   )
 
   "Note: testing assigning self was moved to basic interpreter tests"

--- a/TestSuite/SuperTestSuperClass.som
+++ b/TestSuite/SuperTestSuperClass.som
@@ -26,13 +26,25 @@ THE SOFTWARE.
 "
 
 SuperTestSuperClass = TestCase (
+    | record |
+
+    yourself = (
+        record := record + 1.
+        ^ self
+    )
 
     give42 = (
-        ^42
+        ^ 42
     )
 
     something = (
         ^ #super
     )
+
+    number = (
+        ^ 1
+    )
+
+    @ o = ( ^ self )
 )
 

--- a/TestSuite/SuperTestSuperClass.som
+++ b/TestSuite/SuperTestSuperClass.som
@@ -45,6 +45,10 @@ SuperTestSuperClass = TestCase (
         ^ 1
     )
 
+    key: a key: b = (
+        ^ self
+    )
+
     @ o = ( ^ self )
 )
 


### PR DESCRIPTION
My assumption would be that `super` can only ever be specified for a direct receiver, and does not influence any of the sends following after that.

Though, this seems to be violated in SOM (Java, C, C++, the bytecode interpreters).

The PR introduces a test, which increments a counter differently in the subclass and superclass.
The expected outcome of a situation such as the one below is that we execute yourself 2x in super, and 2x in the self:

```
super yourself yourself @ super yourself yourself.
```

However, the bytecode interpreters seem to execute a third super for the very last yourself.

For completeness, also tested in Pharo. (see [SuperTest.st.txt](https://github.com/SOM-st/SOM/files/4358714/SuperTest.st.txt))

@sophie-kaleba could you review this, and check whether this makes sense?
@fniephaus @krono any opinion?
