### PR TITLE
Added test for correct parsing of string literal starting with new line

### DIFF
--- a/TestSuite/StringTest.som
+++ b/TestSuite/StringTest.som
@@ -50,6 +50,15 @@ StringTest = TestCase (
     self assert: 'r' equals: (str charAt: 6).
   )
 
+  testStringLiteralLineBreak = (
+    | str |
+    "Some parsers get the literals and line bounderies wrong"
+    str := '
+'.
+    self assert: '\n' equals: (str charAt: 1).
+    self assert: 1 equals: str length.
+  )
+
   testPrimSubstringFrom = (
     | str |
     str := 'foobar'.

--- a/TestSuite/StringTest.som
+++ b/TestSuite/StringTest.som
@@ -170,7 +170,7 @@ StringTest = TestCase (
   testLetters = (
     self assert: 'a' isLetters.
     self assert: 'all' isLetters.
-    self expect: 'aOoöéÉíä' isLetters.
+    self expect: 'aOoöéÉíä' isLetters description: 'Does not support Unicode'.
 
     self deny: '' isLetters.
     self deny: ' ' isLetters.


### PR DESCRIPTION
This text reveals a bug in most of the SOM parser implementations.

A string literal that starts with can have strange results.
SOM (Java) does read a `\0` into the string.
Other SOMs do other strange things.