### PR TITLE
add a test for binary operations

### DIFF
--- a/TestSuite/BasicInterpreterTests/BinaryOperation.som
+++ b/TestSuite/BasicInterpreterTests/BinaryOperation.som
@@ -1,0 +1,40 @@
+"
+Copyright (c) 2001-2013 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+BinaryOperation = (
+
+    ----
+
+    test = (
+        ^ (self foo: 1) + (self foo2: 2)
+    )
+
+    foo: aNumber = (
+        ^ 3
+    )
+
+    foo2: aNumber = (
+        ^ 8
+    )
+
+
+)

--- a/TestSuite/BasicInterpreterTests/NumberOfTests.som
+++ b/TestSuite/BasicInterpreterTests/NumberOfTests.som
@@ -26,5 +26,5 @@ NumberOfTests = (
     
     "Return the known number of tests,
      should be used in basic interpreter test harness to confirm completeness"
-    numberOfTests = ( ^ 51 )
+    numberOfTests = ( ^ 52 )
 )


### PR DESCRIPTION
Each operand is a non-primitive message send. 
Helped me debug faulty operations on frames in GraalSOM (see https://github.com/SOM-st/som-java/pull/16)