### PR TITLE
Added `sleep:` and `sleepMillis:` methods in `System`

### DIFF
--- a/Smalltalk/System.som
+++ b/Smalltalk/System.som
@@ -82,7 +82,10 @@ System = (
     "Time"
     time  = primitive
     ticks = primitive      "returns the microseconds since start"
-    
+
+    sleep: secs = ( self sleepMillis: secs * 1000 )
+    sleepMillis: millis = primitive
+
     "Force Garbage Collection"
     fullGC = primitive
     


### PR DESCRIPTION
When testing `System>>#ticks` and `System>>#time`, I was looking for a way to somewhat predictably wait a specific amount of time, regardless of the interpreter's evaluation speed.  
Currently the only way to make the interpreter wait is using a busy wait (something like: `1000000 timesRepeat: nil`), which is not ideal.  
Since thread-sleeping is a commonly available operation, I figured that we could probably expose it to SOM programs to allow them to pause execution efficiently.

So this PR proposes to add the `System>>#sleepMillis:` primitive, to stop evaluating the program for the given amount of time in milliseconds (the only accepted type of argument would be a positive `Integer`).  
This PR also includes the `System>>#sleep:` method, which stops the program for the given amount of time in seconds, rather than in milliseconds, and is implemented in terms of `System>>#sleepMillis:`.