### PR TITLE
Added tests for modulo operations that results to zero

### DIFF
--- a/TestSuite/IntegerTest.som
+++ b/TestSuite/IntegerTest.som
@@ -199,11 +199,13 @@ IntegerTest = TestCase (
     self assert: -2 equals: ( 10 % -3).
     self assert:  2 equals: (-10 %  3).
     self assert: -1 equals: (-10 % -3).
+    self assert:  0 equals: ( 10 %  5).
 
     self assert:  1 equals: ( 10 rem:  3).
     self assert:  1 equals: ( 10 rem: -3).
     self assert: -1 equals: (-10 rem:  3).
     self assert: -1 equals: (-10 rem: -3).
+    self assert:  0 equals: ( 10 rem:  5).
   )
 
   testAbsoluteValue = (


### PR DESCRIPTION
This PR adds tests to verify that the modulo of a number with one of its divisors correctly evaluates to zero.  

I ran this new version of `IntegerTest` on som-rs without the fix from [**Hirevo/som-rs#8**](https://github.com/Hirevo/som-rs/pull/8) applied, and it catches the bug, as expected.
