### PR TITLE
Fallback to main repos in CI if user repos don’t exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,10 @@ install:
       else
         export BRANCH_NAME=$TRAVIS_PULL_REQUEST_BRANCH
         export GITHUB_USER=`echo $TRAVIS_PULL_REQUEST_SLUG | cut -d/ -f1`
+        export PR_TARGET_USER=`echo $TRAVIS_REPO_SLUG | cut -d/ -f1`
       fi
       echo "Get https://github.com/$GITHUB_USER/$REPO at branch $BRANCH_NAME for testing"
-      git clone --branch $BRANCH_NAME --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm || git clone --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm
+      git clone --branch $BRANCH_NAME --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm || git clone --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm || git clone --depth 1 https://github.com/$PR_TARGET_USER/$REPO som-vm
     fi
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
 
     - language: java
       dist: trusty
-      env: SOM=TruffleSOM  REPO=TruffleSOM.git  BUILD=make    SOM="./som -G"
+      env: SOM=TruffleSOM  REPO=TruffleSOM.git  BUILD=ant    SOM="./som -G"
       jdk: [oraclejdk8]
       addons: {apt: {packages: [libc6-dev-i386]}}
 


### PR DESCRIPTION
This hopefully avoids issues with the CI when PRs are sent by users who haven't forked all SOM implementations.