### PR TITLE
Added test to check for nil semantics of uninitialized local variables and empty blocks.

### DIFF
--- a/TestSuite/BasicInterpreterTests/Blocks.som
+++ b/TestSuite/BasicInterpreterTests/Blocks.som
@@ -40,4 +40,19 @@ Blocks = (
         methodLocal := 3.
         a + methodLocal] value: 5)
     )
+    
+    testEmptyZeroArg = (
+      [] value == nil ifTrue: [ ^ 1 ].
+      ^ 2
+    )
+    
+    testEmptyOneArg = (
+      ([:x | ] value: 4) == nil ifTrue: [ ^ 1 ].
+      ^ 2
+    )
+    
+    testEmptyTwoArg = (
+      ([:x :y | ] value: 4 with: 5) == nil ifTrue: [ ^ 1 ].
+      ^ 2
+    )
 )

--- a/TestSuite/BasicInterpreterTests/NumberOfTests.som
+++ b/TestSuite/BasicInterpreterTests/NumberOfTests.som
@@ -26,5 +26,5 @@ NumberOfTests = (
     
     "Return the known number of tests,
      should be used in basic interpreter test harness to confirm completeness"
-    numberOfTests = ( ^ 54 )
+    numberOfTests = ( ^ 57 )
 )

--- a/TestSuite/BasicInterpreterTests/NumberOfTests.som
+++ b/TestSuite/BasicInterpreterTests/NumberOfTests.som
@@ -26,5 +26,5 @@ NumberOfTests = (
     
     "Return the known number of tests,
      should be used in basic interpreter test harness to confirm completeness"
-    numberOfTests = ( ^ 52 )
+    numberOfTests = ( ^ 54 )
 )

--- a/TestSuite/BasicInterpreterTests/Regressions.som
+++ b/TestSuite/BasicInterpreterTests/Regressions.som
@@ -33,4 +33,16 @@ Regressions = (
       'foo:' asSymbol == #foo: ifTrue: [ ^ 1 ].
       ^ 2
     )
+    
+    testUninitializedLocal = (
+      | local |
+      local == nil ifTrue: [ ^ 1 ].
+      ^ 2
+    )
+    
+    testUninitializedLocalInBlock = (
+      [ | local |
+        local == nil ifTrue: [ ^ 1 ] ] value.
+      ^ 2
+    )
 )


### PR DESCRIPTION
Local variables can be uninitialized on first access.
At this point, they should have `nil` as their value.

This is standard Smalltalk semantics, allowing uninitialized access, but ensuring safety by having a well known initial value.