### PR TITLE
Fix error messages when a benchmark isn't found.

### DIFF
--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -88,7 +88,7 @@ BenchmarkHarness = (
         sym := className asSymbol.
         cls := system load: sym.
         cls ifNil: [
-            self error: 'Failed loading benchmark: ', className ].
+            self error: 'Failed loading benchmark: ' + className ].
         benchmarkClass := cls.
     )
         


### PR DESCRIPTION
Previously this led to the following being printed:

```
  ERROR: instance of Vector
```

which was a bit confusing. With this commit it prints:

```
  ERROR: Failed loading benchmark: Richards
```

I found this while getting class paths wrong!