### PR TITLE
Added Integer>>#min: and tests, including for #max:

### DIFF
--- a/Smalltalk/Integer.som
+++ b/Smalltalk/Integer.som
@@ -98,6 +98,10 @@ Integer = (
         (self < otherInt) ifTrue: [^otherInt] ifFalse: [^self].
     )
 
+    min: otherInt = (
+        (self < otherInt) ifTrue: [^self] ifFalse: [^otherInt].
+    )
+
     ----
     
     fromString: aString = primitive

--- a/TestSuite/IntegerTest.som
+++ b/TestSuite/IntegerTest.som
@@ -257,4 +257,35 @@ IntegerTest = TestCase (
     self optional: #toBeSpecified assert: 9223372036854775807 equals:    -1 >>> 1.
     self optional: #toBeSpecified assert: 9223372036854775296 equals: -1024 >>> 1.
   )
+
+  testMin = (
+    "We need to test numbers that are 64bit or less, larger than 64bit,
+     positive, and negative"
+    | big small |
+    big   := #(1 100 9223372036854775807 922337203685477580700
+               -50 -2147483648 922337203685477580700 -922337203685477580700
+               922337203685477580700).
+    small := #(0  52 9223372036854775296 922337203685477529600
+               -51 -2147483650                     1 -922337203685477580701
+               -922337203685477580701).
+  
+    big doIndexes: [:i |
+      self assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
+      self assert: (small at: i)  equals: ((small at: i) min: (big   at: i)) ]
+  )
+  
+  testMax = (
+    "We need to test numbers that are 64bit or less, larger than 64bit,
+     positive, and negative"
+    | big small |
+    big   := #(1 100 9223372036854775807 922337203685477580700
+               -50 -2147483648 922337203685477580700 -922337203685477580700
+               922337203685477580700).
+    small := #(0  52 9223372036854775296 922337203685477529600
+               -51 -2147483650                     1 -922337203685477580701
+               -922337203685477580701).
+    big doIndexes: [:i |
+      self assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
+      self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ]
+  )
 )


### PR DESCRIPTION
This adds the `#min:` method to Integer.
It also adds tests for min and max.

@ltratt I have an issue with yksom building, I assume you may have a custom crate for boehm.
I wouldn't expect much issues from this PR itself, but would be great if you could confirm.
(for build issues, see https://travis-ci.org/github/smarr/SOM/jobs/743737626#L387)