### PR TITLE
Update DoubleTest.som

### DIFF
--- a/TestSuite/DoubleTest.som
+++ b/TestSuite/DoubleTest.som
@@ -43,7 +43,7 @@ DoubleTest = TestCase (
   )
   
   testRound = (
-    self assert:   1 equals:     (5//10) round.
+    self assert:   0 equals:     (5//10) round.
     self assert:   1 equals:    (14//10) round.
     self assert: 445 equals: (44534//100) round.
   )


### PR DESCRIPTION
Integer divisions floors the result. In comparison with Squeak the "correct" behavior is flooring it.

Squeak: 
5 // 10 => 0