### PR TITLE
Github Actions: Make sure we get the branch name also when the action runs in the repo with the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,16 @@ jobs:
           
           GIT_CMDS=(
             "git clone --branch $BRANCH_NAME --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm"
+          )
+
+          if [ ! -z "${{ github.head_ref }}" ]
+          then
+            GIT_CMDS+=(
+              "git clone --branch ${{ github.head_ref }} --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm"
+            )
+          fi
+          
+          GIT_CMDS+=(
             "git clone --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm"
             "git clone --depth 1 https://github.com/$PR_TARGET_USER/$REPO som-vm"
           )


### PR DESCRIPTION
The refs in GitHub actions are a little more complicated.

Documentation is here: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts

To figure out what this means, let's look at the result of:

```bash
echo "What are all these refs anyway?"
echo "github.base_ref: ${{ github.base_ref }}"
echo "github.ref: ${{ github.ref }}"
echo "github.head_ref: ${{ github.head_ref }}"
```

On the repo I pushed to:

```
github.base_ref: 
github.ref: refs/heads/som-som
github.head_ref: 
```

On the repo, I sent the PR to:

```
github.base_ref: master
github.ref: refs/pull/29/merge
github.head_ref: som-som
```

So, the solution is to use the `head_ref` for the repo with the PR, which is what this pull request adds.