### PR TITLE
Reduce code duplication when computing stack depth

### DIFF
--- a/SomSom/src/compiler/MethodGenerationContext.som
+++ b/SomSom/src/compiler/MethodGenerationContext.som
@@ -158,45 +158,30 @@ MethodGenerationContext = (
       | bc |
       bc := bytecode at: i.
 
-      bc == #halt ifTrue: [
-        i := i + 1 ] ifFalse: [
-      bc == #dup  ifTrue: [
-        depth := depth + 1.
-        i := i + 1. ] ifFalse: [
-      (bc == #pushLocal or: [
-       bc == #pushArgument]) ifTrue: [
-          depth := depth + 1.
-          i := i + 3. ] ifFalse: [
-       (bc == #pushField or: [
-        bc == #pushBlock or: [
-        bc == #pushConstant or: [
-        bc == #pushGlobal ] ] ]) ifTrue: [
-           depth := depth + 1.
-           i := i + 2. ] ifFalse: [
-      bc == #pop ifTrue: [
-        depth := depth - 1.
-        i := i + 1. ] ifFalse: [
-      (bc == #popLocal or: [
-       bc == #popArgument ]) ifTrue: [
-          depth := depth - 1.
-          i := i + 3. ] ifFalse: [
-      bc == #popField ifTrue: [
-        depth := depth - 1.
-        i := i + 2. ] ifFalse: [
+      (bc == #dup           or: [
+       bc == #pushLocal     or: [
+       bc == #pushArgument  or: [
+       bc == #pushField     or: [
+       bc == #pushBlock     or: [
+       bc == #pushConstant  or: [
+       bc == #pushGlobal ] ] ] ] ] ])  ifTrue: [
+        depth := depth + 1 ] ifFalse: [
+
+      (bc == #pop         or: [
+       bc == #popLocal    or: [
+       bc == #popArgument or: [
+       bc == #popField ] ] ]) ifTrue: [
+        depth := depth - 1 ] ifFalse: [
+
       (bc == #send or: [bc == #superSend]) ifTrue: [
         | sig |
         "these are special: they need to look at the number of
          arguments (extractable from the signature)"
         sig := literals at: (bytecode at: i + 1).
         depth := depth - sig numberOfSignatureArguments.
-        depth := depth + 1. "return value"
-        i := i + 2 ] ifFalse: [
-      (bc == #returnLocal or: [
-       bc == #returnNonLocal ]) ifTrue: [
-          i := i + 1. ]
-      ifFalse: [
-        self error: 'Illegal bytecode ' + bc asString
-      ] ] ] ] ] ] ] ] ].
+        depth := depth + 1 "return value" ] ] ].
+
+      i := i + (Bytecodes length: bc).
 
       depth > maxDepth ifTrue: [
         maxDepth := depth ] ].


### PR DESCRIPTION
I am now reusing Bytecodes>>length: to avoid defining the length again.

This is I think a good change.
However, just for the record, initially I looked at the method because it blew the bytecode budget.