### PR TITLE
Change to single tick quotes.

### DIFF
--- a/Smalltalk/System.som
+++ b/Smalltalk/System.som
@@ -73,7 +73,7 @@ System = (
                 self global: (current_class name) put: current_class.
                 current_class := current_class superclass. ].
             ^class ].
-        self error: 'Tried loading "' + symbol + '" as a class, but failed.'
+        self error: 'Tried loading \'' + symbol + '\' as a class, but failed.'
     )
 
     "Exiting"


### PR DESCRIPTION
Double tick quick quotes cause problems for lang_tester because we end up wanting to write this test:

```
  "
  VM:
    status: error
    stdout:
      1

      ERROR: Tried loading "unknown" as a class, but failed.
  "
```

However that's impossible (at least in JavaSOM and yksom) which treat this as two comments separated by an identifier "unknown". This seems hard to fix without changing SOM's idea of a comment, so as a hack I think it's easier to change the output that SOM produces.