### PR TITLE
Added a few more tests for super send semantics

### DIFF
--- a/TestSuite/SuperTest.som
+++ b/TestSuite/SuperTest.som
@@ -50,6 +50,39 @@ SuperTest = SuperTestSuperClass (
   number = (
     ^ 10
   )
+  
+  + other = (
+    ^ 11
+  )
+  
+  ++++ other = (
+    ^ 111
+  )
+  
+  keyword: other = (
+    ^ 1111
+  )
+  
+  testBasicUnary = (
+    self assert: 10 equals: self number.
+    self assert:  1 equals: super number.
+  )
+  
+  testBasicBinary = (
+    self assert: 11 equals: self + 3.
+    self assert: 22 equals: super + 5.
+  )
+  
+  
+  testBasicBinaryNonStandardOperator = (
+    self assert: 111 equals: self ++++ 3.
+    self assert: 222 equals: super ++++ 5.
+  )
+  
+  testBasicKeyword = (
+    self assert: 1111 equals: (self keyword: 3).
+    self assert: 2222 equals: (super keyword: 5).
+  )
 
   testWithBinaryUnaryMessage = (
     | val |

--- a/TestSuite/SuperTestSuperClass.som
+++ b/TestSuite/SuperTestSuperClass.som
@@ -44,6 +44,18 @@ SuperTestSuperClass = TestCase (
     number = (
         ^ 1
     )
+    
+    + other = (
+      ^ 22
+    )
+
+    ++++ other = (
+      ^ 222
+    )
+
+    keyword: other = (
+      ^ 2222
+    )
 
     key: a key: b = (
         ^ self


### PR DESCRIPTION
This one reveals that the + operator optimizations in TruffleSOM break super send semantics. (it forgets that it is a super send, and becomes a normal send when it figured out that it isn't adding integers/doubles)

@ltratt as promised.