### PR TITLE
Add Integer>>#== to compare by value

### DIFF
--- a/Smalltalk/Integer.som
+++ b/Smalltalk/Integer.som
@@ -46,7 +46,8 @@ Integer = (
 
     "Comparing"
     =  argument = primitive
-    ~= argument = (^ (self = argument) not )
+    == argument = ( ^self = argument )
+    ~= argument = ( ^(self = argument) not )
     <  argument = primitive
     >  argument = ( ^(self >= argument) and: [ self <> argument ] )
     >= argument = ( ^(self < argument) not )


### PR DESCRIPTION
In `IntegerTest>>testEqualityAndIdentity`, it tests that `==` on Integer objects uses value (not reference) equality. It seems that JsSOM handles this by installing [an `==` primitive on Integer](https://sourcegraph.com/github.com/SOM-st/JsSOM/-/blob/src/som/primitives/IntegerPrimitives.js#L159).

Maybe it makes sense to add `==` to Integer?