### PR TITLE
The handler for #unknownGlobal: and #escapedBlock: should be triggered on self

### DIFF
--- a/TestSuite/BasicInterpreterTests/BlockInlining.som
+++ b/TestSuite/BasicInterpreterTests/BlockInlining.som
@@ -116,7 +116,6 @@ BlockInlining = (
 
     testStackDisciplineFalse = (
       | result |
-      1 halt.
       result := 0 max: (1 < 0 ifTrue: [1] ifFalse: [2]).
       ^ result
     )

--- a/TestSuite/BasicInterpreterTests/Blocks.som
+++ b/TestSuite/BasicInterpreterTests/Blocks.som
@@ -35,10 +35,11 @@ Blocks = (
         a + blockLocal] value: 5)
     )
     
-    testArgAndContext = ( | methodLocal |
-      ^ ([:a |
-        methodLocal := 3.
-        a + methodLocal] value: 5)
+    testArgAndContext = (
+      | methodLocal |
+      ^ [:a |
+          methodLocal := 3.
+          a + methodLocal] value: 5
     )
     
     testEmptyZeroArg = (

--- a/TestSuite/BlockTest.som
+++ b/TestSuite/BlockTest.som
@@ -29,6 +29,10 @@ BlockTest = TestCase (
       ^ [ ^ 42 ]
     )
     
+    escapingNestedBlock = (
+      [ [ ^ [ ^ 43 ] ] value ] value
+    )
+    
     testSimpleBlocks = (
       self assert: 42 equals: self simpleBlock value.
       self assert: 4  equals: (self incBlock value: 3).
@@ -62,6 +66,13 @@ BlockTest = TestCase (
       self assert: 666 equals: escaping_block value.
       self assert: 1 equals: escape_count.
       
+      self assert: escaping_block is: escaped_block.
+      
+      
+      escaping_block := self escapingNestedBlock.
+      self assert: 1 equals: escape_count.
+      self assert: 666 equals: escaping_block value.
+      self assert: 2 equals: escape_count.
       self assert: escaping_block is: escaped_block.
     )
 

--- a/TestSuite/BlockTest.som
+++ b/TestSuite/BlockTest.som
@@ -2,31 +2,31 @@ BlockTest = TestCase (
     |escape_count escaped_block|
 
     simpleBlock = (
-      ^[42]
+      ^ [ 42 ]
     )
 
     incBlock = (
-      ^[ :val | val + 1]
+      ^ [:val | val + 1 ]
     )
 
     "This requires a closure"
     adderBlock: amount = (
-      ^[ :val | amount + val]
+      ^ [:val | amount + val ]
     )
 
     "Closure with mutable state in block"
     counterBlock = (
       |count|
       count := 0.
-      ^[count := count + 1. count]
+      ^ [ count := count + 1. count ]
     )
 
     selfKeeper = (
-      ^[self]
+      ^ [ self ]
     )
 
     escapingBlock = (
-      ^[^42]
+      ^ [ ^ 42 ]
     )
     
     testSimpleBlocks = (

--- a/TestSuite/GlobalTest.som
+++ b/TestSuite/GlobalTest.som
@@ -13,4 +13,20 @@ GlobalTest = TestCase (
       self assert: Nil    equals: nil   class.
       self assert: System equals: system class.
     )
+    
+    escapingBlock = (
+       ^ [ EscapingBlockGlobal ]
+    )
+    
+    testUnknownGlobalSemanticsInBlocks = (
+      self assert: #NormalBlockGlobal is: [ NormalBlockGlobal ] value.
+      self assert: #NormalBlockGlobal is: doesntKnow.
+    
+      self assert: #EscapingBlockGlobal is: self escapingBlock value.
+      self assert: #EscapingBlockGlobal is: doesntKnow.
+      
+      self assert: #NestedBlockGlobal is: [
+         [ [ NestedBlockGlobal ] value ] value ] value.
+      self assert: #NestedBlockGlobal is: doesntKnow.
+    )
 )


### PR DESCRIPTION
This PR adds tests that `#unknownGlobal:` and `#escapedBlock:` are triggered on the `self` of a method, instead of the `blockSelf` of a block, when they are triggered in nested blocks.

I'd argue this is the more useful semantics of the two seemingly implemented by the different SOM implementations at the moment.
Triggering the handlers on the `blockSelf` means the only way to handle the errors would be with a handler on the Block class, which means, there couldn't be any custom handling local to a class.

When asking `self` to handle the errors, we can have class-specific handlers, which seems to make more sense from a flexibility perspective.

And, another point in favor: this is the semantics supported by the original SOM (Java) implementation, and likely CSOM (but not verified).

@ltratt could you run this on ykSOM? My CI setup is blocked by the, I believe known, changes around libgc.

/cc @krono just in case