### PR TITLE
Fix duplicate method names

### DIFF
--- a/Examples/Benchmarks/TestSuite/Block2Test.som
+++ b/Examples/Benchmarks/TestSuite/Block2Test.som
@@ -91,7 +91,7 @@ Block2Test = TestCase (
       self assert: 10 equals: i.
     )
     
-    testWhileTrue = (
+    testWhileFalse = (
       | i |
       i := 1.
       [ i >= 10 ] whileFalse: [ i := i + 1 ].

--- a/Examples/Benchmarks/TestSuite/Block3Test.som
+++ b/Examples/Benchmarks/TestSuite/Block3Test.som
@@ -91,7 +91,7 @@ Block3Test = TestCase (
       self assert: 10 equals: i.
     )
     
-    testWhileTrue = (
+    testWhileFalse = (
       | i |
       i := 1.
       [ i >= 10 ] whileFalse: [ i := i + 1 ].

--- a/Examples/Benchmarks/TestSuite/Block4Test.som
+++ b/Examples/Benchmarks/TestSuite/Block4Test.som
@@ -91,7 +91,7 @@ Block4Test = TestCase (
       self assert: 10 equals: i.
     )
     
-    testWhileTrue = (
+    testWhileFalse = (
       | i |
       i := 1.
       [ i >= 10 ] whileFalse: [ i := i + 1 ].

--- a/Examples/Benchmarks/TestSuite/Block5Test.som
+++ b/Examples/Benchmarks/TestSuite/Block5Test.som
@@ -91,7 +91,7 @@ Block5Test = TestCase (
       self assert: 10 equals: i.
     )
     
-    testWhileTrue = (
+    testWhileFalse = (
       | i |
       i := 1.
       [ i >= 10 ] whileFalse: [ i := i + 1 ].

--- a/Examples/Benchmarks/TestSuite/BlockTest.som
+++ b/Examples/Benchmarks/TestSuite/BlockTest.som
@@ -91,7 +91,7 @@ BlockTest = TestCase (
       self assert: 10 equals: i.
     )
     
-    testWhileTrue = (
+    testWhileFalse = (
       | i |
       i := 1.
       [ i >= 10 ] whileFalse: [ i := i + 1 ].

--- a/Examples/Benchmarks/TestSuite/Boolean2Test.som
+++ b/Examples/Benchmarks/TestSuite/Boolean2Test.som
@@ -86,7 +86,7 @@ Boolean2Test = TestCase (
     pipeBoolFalseTrue  = ( ^ false || [ true  ] )
     pipeBoolFalseFalse = ( ^ false || [ false ] )
     
-    testOr = (
+    testPipe = (
       self assert: self pipeBoolTrueTrue.
       self assert: self pipeBoolTrueFalse.
       self assert: self pipeBoolFalseTrue.

--- a/Examples/Benchmarks/TestSuite/Boolean3Test.som
+++ b/Examples/Benchmarks/TestSuite/Boolean3Test.som
@@ -86,7 +86,7 @@ Boolean3Test = TestCase (
     pipeBoolFalseTrue  = ( ^ false || [ true  ] )
     pipeBoolFalseFalse = ( ^ false || [ false ] )
     
-    testOr = (
+    testPipe = (
       self assert: self pipeBoolTrueTrue.
       self assert: self pipeBoolTrueFalse.
       self assert: self pipeBoolFalseTrue.

--- a/Examples/Benchmarks/TestSuite/Boolean4Test.som
+++ b/Examples/Benchmarks/TestSuite/Boolean4Test.som
@@ -86,7 +86,7 @@ Boolean4Test = TestCase (
     pipeBoolFalseTrue  = ( ^ false || [ true  ] )
     pipeBoolFalseFalse = ( ^ false || [ false ] )
     
-    testOr = (
+    testPipe = (
       self assert: self pipeBoolTrueTrue.
       self assert: self pipeBoolTrueFalse.
       self assert: self pipeBoolFalseTrue.

--- a/Examples/Benchmarks/TestSuite/Boolean5Test.som
+++ b/Examples/Benchmarks/TestSuite/Boolean5Test.som
@@ -86,7 +86,7 @@ Boolean5Test = TestCase (
     pipeBoolFalseTrue  = ( ^ false || [ true  ] )
     pipeBoolFalseFalse = ( ^ false || [ false ] )
     
-    testOr = (
+    testPipe = (
       self assert: self pipeBoolTrueTrue.
       self assert: self pipeBoolTrueFalse.
       self assert: self pipeBoolFalseTrue.

--- a/Examples/Benchmarks/TestSuite/BooleanTest.som
+++ b/Examples/Benchmarks/TestSuite/BooleanTest.som
@@ -86,7 +86,7 @@ BooleanTest = TestCase (
     pipeBoolFalseTrue  = ( ^ false || [ true  ] )
     pipeBoolFalseFalse = ( ^ false || [ false ] )
     
-    testOr = (
+    testPipe = (
       self assert: self pipeBoolTrueTrue.
       self assert: self pipeBoolTrueFalse.
       self assert: self pipeBoolFalseTrue.

--- a/Examples/Benchmarks/TestSuite/Test.som
+++ b/Examples/Benchmarks/TestSuite/Test.som
@@ -201,10 +201,10 @@ Test = Benchmark (
     
     verifyResult: result = (
       "result do: [:e | e println ]."
-      ^ (result at: 1) = 940 and: [
+      ^ (result at: 1) = 950 and: [
           (result at: 2) = 0 and: [
-            (result at: 3) = 940 and: [
-              (result at: 4) = 4935
+            (result at: 3) = 950 and: [
+              (result at: 4) = 4960
         ] ] ]
     )
 )

--- a/Examples/Benchmarks/TestSuite/Vector2Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector2Test.som
@@ -77,15 +77,6 @@ Vector2Test = TestCase (
     self deny: (a contains: #nono).
   )
 
-  testDo = (
-    | j |
-    j := 1.
-    a do: [:i |
-      self assert: i equals: (a at: j).
-      j := j + 1.
-    ].
-  )
-
   testAppendAndRemoveFirst = (
     | v |
     v := Vector new: 10.

--- a/Examples/Benchmarks/TestSuite/Vector3Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector3Test.som
@@ -77,15 +77,6 @@ Vector3Test = TestCase (
     self deny: (a contains: #nono).
   )
 
-  testDo = (
-    | j |
-    j := 1.
-    a do: [:i |
-      self assert: i equals: (a at: j).
-      j := j + 1.
-    ].
-  )
-
   testAppendAndRemoveFirst = (
     | v |
     v := Vector new: 10.

--- a/Examples/Benchmarks/TestSuite/Vector4Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector4Test.som
@@ -77,15 +77,6 @@ Vector4Test = TestCase (
     self deny: (a contains: #nono).
   )
 
-  testDo = (
-    | j |
-    j := 1.
-    a do: [:i |
-      self assert: i equals: (a at: j).
-      j := j + 1.
-    ].
-  )
-
   testAppendAndRemoveFirst = (
     | v |
     v := Vector new: 10.

--- a/Examples/Benchmarks/TestSuite/Vector5Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector5Test.som
@@ -77,15 +77,6 @@ Vector5Test = TestCase (
     self deny: (a contains: #nono).
   )
 
-  testDo = (
-    | j |
-    j := 1.
-    a do: [:i |
-      self assert: i equals: (a at: j).
-      j := j + 1.
-    ].
-  )
-
   testAppendAndRemoveFirst = (
     | v |
     v := Vector new: 10.

--- a/Examples/Benchmarks/TestSuite/VectorTest.som
+++ b/Examples/Benchmarks/TestSuite/VectorTest.som
@@ -77,15 +77,6 @@ VectorTest = TestCase (
     self deny: (a contains: #nono).
   )
 
-  testDo = (
-    | j |
-    j := 1.
-    a do: [:i |
-      self assert: i equals: (a at: j).
-      j := j + 1.
-    ].
-  )
-
   testAppendAndRemoveFirst = (
     | v |
     v := Vector new: 10.

--- a/TestSuite/BlockTest.som
+++ b/TestSuite/BlockTest.som
@@ -91,7 +91,7 @@ BlockTest = TestCase (
       self assert: 10 equals: i.
     )
     
-    testWhileTrue = (
+    testWhileFalse = (
       | i |
       i := 1.
       [ i >= 10 ] whileFalse: [ i := i + 1 ].

--- a/TestSuite/BooleanTest.som
+++ b/TestSuite/BooleanTest.som
@@ -86,7 +86,7 @@ BooleanTest = TestCase (
     pipeBoolFalseTrue  = ( ^ false || [ true  ] )
     pipeBoolFalseFalse = ( ^ false || [ false ] )
     
-    testOr = (
+    testPipe = (
       self assert: self pipeBoolTrueTrue.
       self assert: self pipeBoolTrueFalse.
       self assert: self pipeBoolFalseTrue.

--- a/TestSuite/VectorTest.som
+++ b/TestSuite/VectorTest.som
@@ -77,15 +77,6 @@ VectorTest = TestCase (
     self deny: (a contains: #nono).
   )
 
-  testDo = (
-    | j |
-    j := 1.
-    a do: [:i |
-      self assert: i equals: (a at: j).
-      j := j + 1.
-    ].
-  )
-
   testAppendAndRemoveFirst = (
     | v |
     v := Vector new: 10.


### PR DESCRIPTION
The new tests included bugs where some methods had the same name.
Rename or remove those and update the expected numbers in the benchmark.