### PR TITLE
Remove Warmup Support and Add Explicit GC to Benchmark Harness

### DIFF
--- a/Examples/Benchmarks/Benchmark.som
+++ b/Examples/Benchmarks/Benchmark.som
@@ -30,9 +30,7 @@ Benchmark = (
         harness initialize.
         harness benchmarkClass: self class.
         harness printAll: false.
-        harness maxRuntime: 3. "seconds"
         harness numIterations: 100.
-        harness warmUp: 10.
 
         harness runBenchmark.
         harness printTotal.

--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -26,7 +26,7 @@ BenchmarkHarness = (
     passed a list of benchmarks to run (class names) as arguments. It will
     run each of them and output single as well as a total."
     
-    | total benchmarkClass numIterations warmUp innerIterations maxRuntime printAll |
+    | total benchmarkClass numIterations innerIterations printAll doGC |
     
     benchmarkClass: class = ( benchmarkClass := class )
     printAll: aBool = ( printAll := aBool )
@@ -50,11 +50,13 @@ BenchmarkHarness = (
         numIterations := 1.
         innerIterations := 1.
         printAll      := true.
+        doGC          := false.
     )
     
     printUsage = (
-      './som.sh -cp Smalltalk Examples/Benchmarks/BenchmarkHarness.som [benchmark] [num-iterations [warm-up [inner-iter]]]' println.
+      './som.sh -cp Smalltalk Examples/Benchmarks/BenchmarkHarness.som [--gc-between-iterations|-gc] benchmark [num-iterations [inner-iter]]' println.
       '' println.
+      '  --gc-between-iterations | --gc  - trigger a full GC between benchmark iteratons' println.
       '  benchmark      - benchmark class name (e.g., Queens, Fibonacci, Dispatch)' println.
       '  num-iterations - number of times to execute benchmark, default: 1' println.
       '  inner-iter     - number of times the benchmark is executed in an inner loop, ' println.
@@ -62,15 +64,26 @@ BenchmarkHarness = (
     )
     
     processArguments: args = (
-        self loadBenchmarkClass: (args at: 2). "First argument is the BenchmarkHarness"
-        args length > 2 ifTrue: [
-            numIterations := (args at: 3) asInteger.
-            args length > 3 ifTrue: [
-                args length > 4 ifTrue: [
-                    innerIterations := (args at: 5) asInteger.
-                ].
-            ].
-        ]
+        | v arg |
+        v := Vector new: args length.
+        v appendAll: args.
+        
+        "First argument is the BenchmarkHarness"
+        v removeFirst.
+        
+        arg := v removeFirst.
+        (arg = '--gc-between-iterations' or: [arg = '--gc'])
+          ifTrue: [
+            doGC := true.
+            arg := v removeFirst ].
+        
+        self loadBenchmarkClass: arg. 
+        v size > 0 ifTrue: [
+          arg := v removeFirst.
+          numIterations := arg asInteger.
+          v size > 0 ifTrue: [
+            arg := v removeFirst.
+            innerIterations := arg asInteger ] ]
     )
     
     loadBenchmarkClass: className = (
@@ -112,8 +125,9 @@ BenchmarkHarness = (
         
             total := total + runTime.
             i := i + 1.
-        
-            system fullGC ].
+
+            doGC ifTrue: [
+              system fullGC ] ].
     
         ^ total
     )

--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -31,13 +31,7 @@ BenchmarkHarness = (
     benchmarkClass: class = ( benchmarkClass := class )
     printAll: aBool = ( printAll := aBool )
 
-    maxRuntime: seconds = (
-        "converted to microseconds i.e. ticks"
-        seconds ifNotNil: [
-            maxRuntime := seconds * 1000 * 1000] )
-
     numIterations: anInt = (numIterations := anInt)
-    warmUp: anInt = (warmUp := anInt)
     
     total = ( ^ total )
     
@@ -54,9 +48,7 @@ BenchmarkHarness = (
     initialize = (
         total         := 0.
         numIterations := 1.
-        warmUp        := 0.
         innerIterations := 1.
-        maxRuntime    := nil.
         printAll      := true.
     )
     
@@ -65,7 +57,6 @@ BenchmarkHarness = (
       '' println.
       '  benchmark      - benchmark class name (e.g., Queens, Fibonacci, Dispatch)' println.
       '  num-iterations - number of times to execute benchmark, default: 1' println.
-      '  warm-up        - number of times to execute benchmark before measuring, default: 0' println.
       '  inner-iter     - number of times the benchmark is executed in an inner loop, ' println.
       '                   which is measured in total, default: 1' println.
     )
@@ -75,7 +66,6 @@ BenchmarkHarness = (
         args length > 2 ifTrue: [
             numIterations := (args at: 3) asInteger.
             args length > 3 ifTrue: [
-                warmUp := (args at: 4) asInteger.
                 args length > 4 ifTrue: [
                     innerIterations := (args at: 5) asInteger.
                 ].
@@ -98,36 +88,11 @@ BenchmarkHarness = (
         bench oneTimeSetup.
         
         ('Starting ' + bench name + ' benchmark ... ') print.
-        self doWarmup: bench.
         result := self doRuns: bench.
         total := total + result.
         self reportBenchmark: bench result: result.
 
         '' println
-    )
-    
-    doWarmup: bench = (
-        | numIterationsTmp printAllTmp maxRuntimeTmp |
-        warmUp > 0 ifFalse: [
-            '' println.
-            ^ self].
-
-        numIterationsTmp := numIterations.
-        printAllTmp      := printAll.
-        maxRuntimeTmp    := maxRuntime.
-
-        numIterations := warmUp.
-        printAll      := false.
-        maxRuntime    := nil.
-
-        ' warmup ...' print.
-        self doRuns: bench.
-
-        numIterations := numIterationsTmp.
-        printAll      := printAllTmp.
-        maxRuntime    := maxRuntimeTmp.
-
-        ' completed.' println.
     )
     
     doRuns: bench = (
@@ -147,11 +112,6 @@ BenchmarkHarness = (
         
             total := total + runTime.
             i := i + 1.
-        
-            maxRuntime ifNotNil: [
-                total > maxRuntime ifTrue: [
-                    numIterations := i.
-                    ^ total ]].
         
             system fullGC ].
     


### PR DESCRIPTION
- remove support for warmup, because it's better to do it on the data than some broken way in a harness. Having different call sites will cause compilation and distort results.
- remove max run time, which hasn't been used in ages
- add flag to explicitly force GC between benchmark iterations. This is to make sure we see in the benchmark configuration whether GC is force or not.