### PR TITLE
Added `Integer>>#raisedTo:` and `Double>>#raisedTo:`

### DIFF
--- a/Smalltalk/Double.som
+++ b/Smalltalk/Double.som
@@ -39,10 +39,10 @@ Double = (
     cos         = primitive
     sin         = primitive
 
-    pow: exp = (
-        | output |
-        output := 1.
-        exp timesRepeat: [ output := output * self ].
+    raisedTo: exponent = (
+        | factor output |
+        output := 1.0.
+        exponent timesRepeat: [ output := output * self ].
         ^ output
     )
 

--- a/Smalltalk/Double.som
+++ b/Smalltalk/Double.som
@@ -40,7 +40,7 @@ Double = (
     sin         = primitive
 
     raisedTo: exponent = (
-        | factor output |
+        | output |
         output := 1.0.
         exponent timesRepeat: [ output := output * self ].
         ^ output

--- a/Smalltalk/Double.som
+++ b/Smalltalk/Double.som
@@ -39,6 +39,13 @@ Double = (
     cos         = primitive
     sin         = primitive
 
+    pow: exp = (
+        | output |
+        output := 1.
+        exp timesRepeat: [ output := output * self ].
+        ^ output
+    )
+
     "Comparing"
     =  argument = primitive
     <  argument = primitive

--- a/Smalltalk/Double.som
+++ b/Smalltalk/Double.som
@@ -40,9 +40,13 @@ Double = (
     sin         = primitive
 
     raisedTo: exponent = (
+        "Raise the receiver to the given exponent.
+         Currently only positive integer exponents
+         are fully supported."
         | output |
         output := 1.0.
-        exponent timesRepeat: [ output := output * self ].
+        exponent asInteger 
+          timesRepeat: [ output := output * self ].
         ^ output
     )
 

--- a/Smalltalk/Integer.som
+++ b/Smalltalk/Integer.som
@@ -67,6 +67,7 @@ Integer = (
     as32BitSignedValue   = primitive " returns an int, with the value that a signed 32-bit integer would have"
     as32BitUnsignedValue = primitive " returns an int, with the value that a unsigned 32-bit integer would have"
     asDouble    = primitive
+    asInteger   = ( ^self )
 
     hashcode    = ( ^self )
 

--- a/Smalltalk/Integer.som
+++ b/Smalltalk/Integer.som
@@ -41,10 +41,10 @@ Integer = (
     sqrt        = primitive
     negated     = ( ^0 - self )
 
-    pow: exp = (
+    raisedTo: exponent = (
         | output |
         output := 1.
-        exp timesRepeat: [ output := output * self ].
+        exponent timesRepeat: [ output := output * self ].
         ^ output
     )
 

--- a/Smalltalk/Integer.som
+++ b/Smalltalk/Integer.som
@@ -42,9 +42,13 @@ Integer = (
     negated     = ( ^0 - self )
 
     raisedTo: exponent = (
+        "Raise the receiver to the given exponent.
+         Currently only positive integer exponents
+         are fully supported."
         | output |
         output := 1.
-        exponent timesRepeat: [ output := output * self ].
+        exponent asInteger
+          timesRepeat: [ output := output * self ].
         ^ output
     )
 

--- a/Smalltalk/Integer.som
+++ b/Smalltalk/Integer.som
@@ -41,6 +41,13 @@ Integer = (
     sqrt        = primitive
     negated     = ( ^0 - self )
 
+    pow: exp = (
+        | output |
+        output := 1.
+        exp timesRepeat: [ output := output * self ].
+        ^ output
+    )
+
     "Random numbers"
     atRandom = primitive
 

--- a/TestSuite/DoubleTest.som
+++ b/TestSuite/DoubleTest.som
@@ -102,6 +102,18 @@ DoubleTest = TestCase (
 
     self assert:    0.0 equals: ( 0.0 raisedTo: 5).
     self assert:    1.0 equals: ( 0.0 raisedTo: 0).
+    
+    "Negative exponents are not yet supported"
+    self assert: 1.0 equals: ( 0.0 raisedTo:  -1).
+    self assert: 1.0 equals: ( 0.0 raisedTo:  -2).
+    self assert: 1.0 equals: (10.0 raisedTo:  -1).
+    self assert: 1.0 equals: (10.0 raisedTo:  -2).
+    
+    "Double exponents are not yet supported"
+    self assert: 2.0 equals: ( 2.0 raisedTo:  1.5).
+    self assert: 4.0 equals: ( 2.0 raisedTo:  2.4).
+    self assert: 4.0 equals: ( 2.0 raisedTo:  2.9).
+    self assert: 1.0 equals: ( 2.0 raisedTo:  -2.2).
   )
   
   testNegated = (

--- a/TestSuite/DoubleTest.som
+++ b/TestSuite/DoubleTest.som
@@ -87,6 +87,22 @@ DoubleTest = TestCase (
     
     self assert: 23453456.0 equals: (23453456.0 * 23453456.0) sqrt.
   )
+
+  testRaisedTo = (
+    self assert:    1.0 equals: ( 2.0 raisedTo: 0).
+    self assert:    2.0 equals: ( 2.0 raisedTo: 1).
+    self assert:    8.0 equals: ( 2.0 raisedTo: 3).
+    self assert:  256.0 equals: ( 2.0 raisedTo: 8).
+
+    self assert:  256.0 equals: (-2.0 raisedTo: 8).
+    self assert: -128.0 equals: (-2.0 raisedTo: 7).
+
+    self assert:   6.25 equals: ( 2.5 raisedTo: 2).
+    self assert: 5.0625 equals: ( 1.5 raisedTo: 4).
+
+    self assert:    0.0 equals: ( 0.0 raisedTo: 5).
+    self assert:    1.0 equals: ( 0.0 raisedTo: 0).
+  )
   
   testNegated = (
     self assert:  0.0 equals:  0.0 negated.

--- a/TestSuite/IntegerTest.som
+++ b/TestSuite/IntegerTest.som
@@ -243,6 +243,20 @@ IntegerTest = TestCase (
     self assert: Integer equals: (25 sqrt class).
   )
 
+  testRaisedTo = (
+    self assert:                               1 equals: ( 2 raisedTo:   0).
+    self assert:                               2 equals: ( 2 raisedTo:   1).
+    self assert:                               8 equals: ( 2 raisedTo:   3).
+    self assert:                             256 equals: ( 2 raisedTo:   8).
+    self assert: 1267650600228229401496703205376 equals: ( 2 raisedTo: 100).
+
+    self assert:                             256 equals: (-2 raisedTo:   8).
+    self assert:                            -128 equals: (-2 raisedTo:   7).
+
+    self assert:                               0 equals: ( 0 raisedTo:   5).
+    self assert:                               1 equals: ( 0 raisedTo:   0).
+  )
+
   testAnd = (
     self assert: 0 equals: (2 & 1).
     self assert: 2 equals: (2 & 2).

--- a/TestSuite/IntegerTest.som
+++ b/TestSuite/IntegerTest.som
@@ -255,6 +255,18 @@ IntegerTest = TestCase (
 
     self assert:                               0 equals: ( 0 raisedTo:   5).
     self assert:                               1 equals: ( 0 raisedTo:   0).
+    
+    "Negative exponents are not yet supported"
+    self assert:                               1 equals: ( 0 raisedTo:  -1).
+    self assert:                               1 equals: ( 0 raisedTo:  -2).
+    self assert:                               1 equals: (10 raisedTo:  -1).
+    self assert:                               1 equals: (10 raisedTo:  -2).
+    
+    "Double exponents are not yet supported"
+    self assert:                               2 equals: ( 2 raisedTo:  1.5).
+    self assert:                               4 equals: ( 2 raisedTo:  2.4).
+    self assert:                               4 equals: ( 2 raisedTo:  2.9).
+    self assert:                               1 equals: ( 2 raisedTo:  -2.2).
   )
 
   testAnd = (


### PR DESCRIPTION
This PR proposes to add a `#pow:` method for both `Integer` and `Double` to raise a number to a given power.  

Raising a number to a power is a common operation that could be useful to just have available in the core-lib, just like others like `#abs` or `#min:`.  

I needed it in my SOM implementation of day 2 of the Advent of Code and I had to write [a separate method](https://github.com/Hirevo/advent-of-code-2021/blob/e2e1c0881c084855013739f66f12f353cff99088/som/Day03.som#L14-L19) to have it available.  