### PR TITLE
Fixed bugs in `Vector>>#first` and `Vector>>#contains:`

### DIFF
--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -100,9 +100,8 @@ Vector = (
     )
 
     contains: anObject = (
-        first to: last - 1 do: [ :idx |
-            (storage at: idx) = anObject ifTrue: [ ^ true ]
-        ].
+        first to: last - 1 do: [ :i |
+            (storage at: i) = anObject ifTrue: [ ^ true ] ].
         ^ false
     )
 

--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -36,7 +36,7 @@ Vector = (
         ^ self checkIndex: index ifValid: [ storage at: index put: value ]
     )
 
-    first = ( ^ (self size > 0) ifTrue: [storage at: 1] ifFalse: [nil] )
+    first = ( ^ (self size > 0) ifTrue: [storage at: first] ifFalse: [nil] )
     last  = ( ^ (self size > 0) ifTrue: [storage at: last - 1] ifFalse: [nil] )
 
     "Iterating"
@@ -100,7 +100,10 @@ Vector = (
     )
 
     contains: anObject = (
-        ^ storage contains: anObject
+        first to: last - 1 do: [ :idx |
+            (storage at: idx) = anObject ifTrue: [ ^ true ]
+        ].
+        ^ false
     )
 
     "If anObject is in vector, return index of first occurance.

--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -100,8 +100,8 @@ Vector = (
     )
 
     contains: anObject = (
-        first to: last - 1 do: [ :i |
-            (storage at: i) = anObject ifTrue: [ ^ true ] ].
+        self do: [ :element |
+            element = anObject ifTrue: [ ^ true ] ].
         ^ false
     )
 

--- a/TestSuite/VectorTest.som
+++ b/TestSuite/VectorTest.som
@@ -73,7 +73,32 @@ VectorTest = TestCase (
   )
 
   testContains = (
+    self assert: (a contains: 'hello').
+    self assert: (a contains: #world).
     self assert: (a contains: 23).
+    self deny: (a contains: #nono).
+  )
+  
+  testContainsAfterRemoveFirst = (
+    a removeFirst.
+    
+    self deny: (a contains: 'hello').
+    self assert: (a contains: #world).
+    self assert: (a contains: 23).
+    self deny: (a contains: #nono).
+    
+    a removeFirst.
+    
+    self deny: (a contains: 'hello').
+    self deny: (a contains: #world).
+    self assert: (a contains: 23).
+    self deny: (a contains: #nono).
+    
+    a removeFirst.
+    
+    self deny: (a contains: 'hello').
+    self deny: (a contains: #world).
+    self deny: (a contains: 23).
     self deny: (a contains: #nono).
   )
 

--- a/TestSuite/VectorTest.som
+++ b/TestSuite/VectorTest.som
@@ -54,7 +54,7 @@ VectorTest = TestCase (
       self assert: 1 equals: v first ].
 
     1 to: 10 do: [:i |
-      self assert: 1 equals: v first.
+      self assert: i equals: v first.
       v removeFirst ]
   )
 


### PR DESCRIPTION
This PR fixes two bugs I found in the `Vector` class while using it to solve the Advent of Code.  

The first one is simply `Vector>>#first` returning the element at index `1` instead of the element at index `first`, which would return the incorrect element if `Vector>>#removeFirst` was previously used.

The second one is that `Vector>>#contains:` deferred to `Array>>#contains:`, which does not take into account the `first` and `last` indexes, and therefore can consider elements that have been removed as still being contained in the vector.

Minimal example:

```smalltalk
MyVectorTest = (
    run: args = (
        | vec |

        vec := 2, 3, 4.

        vec removeFirst.  " <-- this removes the `2` from the vector "

        vec first println.          " <-- we expected `3`, but we got `2` "
        (vec contains: 2) println.  " <-- we expected `false`, but we got `true` "
    )
)
```