### PR TITLE
Fixed various issues related to `Vector` indices

### DIFF
--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -30,9 +30,13 @@ Vector = (
     | first last storage |
 
     "Accessing"
-    at: index = ( ^ self checkIndex: index ifValid: [ storage at: index ] )
+    at: index = (
+        index := index + first - 1.
+        ^ self checkIndex: index ifValid: [ storage at: index ]
+    )
 
     at: index put: value = (
+        index := index + first - 1.
         ^ self checkIndex: index ifValid: [ storage at: index put: value ]
     )
 
@@ -45,7 +49,7 @@ Vector = (
     )
 
     doIndexes: block = (
-        first to: last - 1 do: block
+        1 to: last - first do: block
     )
 
     "Adding"
@@ -107,7 +111,7 @@ Vector = (
      If it isn't, return -1."
     indexOf: anObject = (
         first to: last - 1 do: [ :i |
-            (storage at: i) = anObject ifTrue: [ ^ i ] ].
+            (storage at: i) = anObject ifTrue: [ ^ i - first + 1 ] ].
         ^ -1
     )
 
@@ -138,7 +142,7 @@ Vector = (
     )
 
     checkIndex: index ifValid: block = (
-        ^ ((first <= index) && (index <= last)
+        ^ ((first <= index) && (index < last)
             ifTrue: [ block value ]
             ifFalse: [
                 self error:

--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -31,13 +31,15 @@ Vector = (
 
     "Accessing"
     at: index = (
-        index := index + first - 1.
-        ^ self checkIndex: index ifValid: [ storage at: index ]
+        | storeIdx |
+        storeIdx := index + first - 1.
+        ^ self checkIndex: storeIdx ifValid: [ storage at: storeIdx ]
     )
 
     at: index put: value = (
-        index := index + first - 1.
-        ^ self checkIndex: index ifValid: [ storage at: index put: value ]
+        | storeIdx |
+        storeIdx := index + first - 1.
+        ^ self checkIndex: storeIdx ifValid: [ storage at: storeIdx put: value ]
     )
 
     first = ( ^ (self size > 0) ifTrue: [storage at: 1] ifFalse: [nil] )

--- a/TestSuite/VectorTest.som
+++ b/TestSuite/VectorTest.som
@@ -43,6 +43,37 @@ VectorTest = TestCase (
     self assert: #world equals: (a at: 2).
     self assert:     23 equals: (a at: 3).
   )
+  
+  testAtPut = (
+    self assert: 'hello' equals: (a at: 1).
+    a at: 1 put: 11.
+    
+    self assert: 11 equals: (a at: 1).
+    
+    self assert: #world equals: (a at: 2).
+    self assert:     23 equals: (a at: 3).
+    
+    a at: 3 put: 33.
+    self assert: 33 equals: (a at: 3).
+  )
+  
+  testAtAfterRemoveFirst = (
+    self assert: 'hello' equals: (a at: 1).
+    a removeFirst.
+    self assert: #world equals: (a at: 1).
+    self assert:     23 equals: (a at: 2).
+  )
+  
+  testAtPutAfterRemoveFirst = (
+    a removeFirst.
+    a at: 1 put: 11.
+    a at: 2 put: 22.
+    
+    self assert: 11 equals: (a at: 1).
+    self assert: 22 equals: (a at: 2).
+    
+    self assert: 2 equals: a size
+  )
 
   testFirst = (
     | v |
@@ -149,6 +180,21 @@ VectorTest = TestCase (
     self assert: 2 equals: (arr at: 2).
   )
   
+  testAsArrayAfterRemoveFirst = (
+    | v arr |
+    v := Vector new.
+    v append: 1.
+    v append: 2.
+    v append: 5.
+    
+    v removeFirst.
+
+    arr := v asArray.
+    self assert: 2 equals: arr length.
+    self assert: 2 equals: (arr at: 1).
+    self assert: 5 equals: (arr at: 2).
+  )
+  
   testAsSet = (
     | v set |
     v := Vector new.
@@ -232,6 +278,21 @@ VectorTest = TestCase (
       i := i + 1.
     ].
     self assert: 6 equals: i.
+  )
+  
+  testDoIndexesAfterRemoveFirst = (
+    | i v |
+    v := Vector new.
+    v appendAll: #(1 2 3 4 5).
+    
+    v removeFirst.
+    
+    i := 1.
+    v doIndexes: [:j |
+      self assert: i equals: j.
+      i := i + 1 ].
+    
+    self assert: 5 equals: i.
   )
   
   testDo = (


### PR DESCRIPTION
As I was continuing to use the `Vector` class more and more intensely when solving the Advent of Code puzzles, I discovered some more potential issues about how `Vector` behaves after a call to `Vector>>#removeFirst`, specifically around the indices that it uses and/or allows.

After a single call to `Vector>>#removeFirst` for example, the current behaviour is that:
- `Vector>>#doIndexes:` will give indices starting from `2` (the value of its `first` variable), instead of `1`.
- `Vector>>#asArray` will start indexing out of bounds of its temporary array as it is filling it in, resulting in some `nil` values in its output array.
- `Vector>>#at:` and `Vector>>#at:put:` will do nothing (that is observable to the caller) on index `1` (because it is now less than `first`)

This PR fixes these issues and makes it so that the user always uses and observes indices starting from 1 onwards (the vector takes care of making it relative to `first` when indexing into `storage`).

And another unrelated bug fix that I have included here is that an off-by-one access past the end of the vector simply always returned nil, instead of calling `Object>>#error:` (which is invoked starting from off-by-two errors).

Here is some code that shows the bugs:
```smalltalk
MyVectorTest = (
    | vec |

    vec := 42, 65, 34, 73, 24, 20.

    vec removeFirst.       " <- this correctly returned `42` "
    vec removeFirst.       " <- this correctly returned `65` "

    vec asArray.           " <- BUG: this returned `#(nil nil 34 73)` instead of `#(34 73 24 20)` "

    vec doIndexes: [ :idx | idx print ]. '' println.   " <- BUG: this printed `3456` instead of `1234` "

    (vec at: 2) println.  " <- BUG: this crashed the program with an `index 2 out-of-bounds of [3..7]` message "
    vec at: 1 put: 99.    " <- BUG: this also crashed the program with an `index 1 out-of-bounds of [3..7]` message "

    " Another slight bug about indices, but needing to call `Vector>>#removeFirst:` beforehand to trigger it "
    Vector new at: 1.   " <- BUG: this returned nil, instead of an raising an off-by-one error, although it did if we used `2` instead "
)
```