### PR TITLE
Fixed `Vector>>#remove` and `Vector>>#removeFirst` to allow deallocations

### DIFF
--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -77,11 +77,12 @@ Vector = (
 
     "Removing"
     remove = (
-        (last > first)
-            ifTrue:  [ last := last - 1. ^storage at: last ]
-            ifFalse: [
-                self error:
-                    'Vector: Attempting to pop element from empty Vector' ]
+        | value |
+        self isEmpty ifTrue: [ self error: 'Vector: Attempting to pop element from empty Vector' ].
+        last := last - 1.
+        value := storage at: last.
+        storage at: last put: nil.
+        ^ value
     )
 
     remove: object = (
@@ -156,9 +157,12 @@ Vector = (
 
     "DeltaBlue"
     removeFirst = (
+        | value |
         self isEmpty ifTrue: [ self error: 'OrderedCollection is empty' ].
+        value := storage at: first.
+        storage at: first put: nil.
         first := first + 1.
-        ^ storage at: first - 1
+        ^ value
     )
 
     "Conversion"

--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -158,7 +158,7 @@ Vector = (
     "DeltaBlue"
     removeFirst = (
         | value |
-        self isEmpty ifTrue: [ self error: 'OrderedCollection is empty' ].
+        self isEmpty ifTrue: [ self error: 'Vector: Attempting to remove the first element from an empty Vector' ].
         value := storage at: first.
         storage at: first put: nil.
         first := first + 1.

--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -78,7 +78,7 @@ Vector = (
     "Removing"
     remove = (
         | value |
-        self isEmpty ifTrue: [ self error: 'Vector: Attempting to pop element from empty Vector' ].
+        self isEmpty ifTrue: [ self error: 'Vector: Attempting to remove the last element from an empty Vector' ].
         last := last - 1.
         value := storage at: last.
         storage at: last put: nil.

--- a/TestSuite/VectorTest.som
+++ b/TestSuite/VectorTest.som
@@ -132,6 +132,18 @@ VectorTest = TestCase (
     self deny: (a contains: 23).
     self deny: (a contains: #nono).
   )
+  
+  testContainsAfterRemovals = (
+    self deny: (a contains: nil).
+    
+    a removeFirst.
+    self deny: (a contains: nil).
+    
+    a remove.
+    self deny: (a contains: nil).
+    
+    self assert: (a contains: #world).
+  )
 
   testAppendAndRemoveFirst = (
     | v |


### PR DESCRIPTION
This PR aims to fix a little issue that I spotted and that I think could be considered as a minor bug, that prevented items removed from a `Vector` to be garbage-collected.

Currently, the `Vector>>#remove` and `Vector>>#removeFirst` methods are implemented by simply changing the bounds used when looking into the internal underlying storage array.  

The issue with simply doing this is that the value is kept as-is, in that underlying array, which means it is still being counted as being reachable by garbage-collectors, even if the user of the `Vector` discarded the removed item that got returned and didn't keep any aliases to it.

This could result in some unexpected memory leaks.

This PR fixes that problem by making sure to place a `nil` value at the location of removed items.

Minimal example of the bug:
```smalltalk
MyVectorTest = (
    run = (
        | vec |

        " We first create an empty vector ... "
        vec := Vector new.

        " We push some object into it (here, I am using some new instance) ... "
        " (notice that `vec` thus becomes the only object that can reach that instance) "
        vec push: MyVectorTest new.

        " We then remove that object from the vector, disregarding the returned value ... "
        " (The instance should now be considered unreachable) "
        vec remove.

        " BUG: Even after that `system fullGC` call, the previously removed object is guaranteed to still be allocated. "
        " Because `vec` is quietly keeping it alive, even though we, as a user, can not reach it anymore "
        system fullGC.
    )
)
```
