### PR TITLE
Only extend the Vector storage when we really need to

### DIFF
--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -58,7 +58,7 @@ Vector = (
     , element = ( ^self append: element )
 
     append: element = (
-        (last >= storage length) ifTrue: [
+        (last > storage length) ifTrue: [
             "Need to expand capacity first"
             | newStorage |
             newStorage := Array new: (2 * storage length).


### PR DESCRIPTION
The condition is changed from >= to >.
The later is less eager, by one element.

This is likely going to influence benchmark results.
It should not influence correctness, because there was enough space in the storage for the `=` case, since we have 1-based indexing.