### PR TITLE
Add primitives for basic GC and compilation statistics to System

### DIFF
--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -114,16 +114,17 @@ BenchmarkHarness = (
         total := 0.
     
         [ i < numIterations ] whileTrue: [
-            | startTime endTime runTime gcStats comp|
+            | startTime endTime runTime gcStats |
             startTime := system ticks.
             (bench innerBenchmarkLoop: innerIterations) ifFalse: [
               self error: 'Benchmark failed with incorrect result'. ].
             endTime   := system ticks.
             gcStats   := system gcStats.
-            'gc-count:          ' print. ((gcStats) at: 1) println.
-            'gc-time (ms):      ' print. ((gcStats) at: 2) println.
-            'compile-time (ms): ' print. system compilerTime println.
-        
+
+            bench name print. ': GC count:     ' print. ((gcStats) at: 1) print. 'n' println.
+            bench name print. ': GC time:      ' print. ((gcStats) at: 2) print. 'ms' println.
+            bench name print. ': Compile time: ' print. system compilerTime print. 'ms' println.
+
             runTime := endTime - startTime.
             printAll ifTrue: [ self print: bench run: runTime ].
         

--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -114,11 +114,15 @@ BenchmarkHarness = (
         total := 0.
     
         [ i < numIterations ] whileTrue: [
-            | startTime endTime runTime |
+            | startTime endTime runTime gcStats comp|
             startTime := system ticks.
             (bench innerBenchmarkLoop: innerIterations) ifFalse: [
               self error: 'Benchmark failed with incorrect result'. ].
             endTime   := system ticks.
+            gcStats   := system gcStats.
+            'gc-count:          ' print. ((gcStats) at: 1) println.
+            'gc-time (ms):      ' print. ((gcStats) at: 2) println.
+            'compile-time (ms): ' print. system compilerTime println.
         
             runTime := endTime - startTime.
             printAll ifTrue: [ self print: bench run: runTime ].

--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -114,16 +114,19 @@ BenchmarkHarness = (
         total := 0.
     
         [ i < numIterations ] whileTrue: [
-            | startTime endTime runTime gcStats |
+            | startTime endTime runTime endGcStats startGcStats startCompTime endCompTime |
+            startGcStats := system gcStats.
+            startCompTime := system totalCompilationTime.
             startTime := system ticks.
             (bench innerBenchmarkLoop: innerIterations) ifFalse: [
               self error: 'Benchmark failed with incorrect result'. ].
             endTime   := system ticks.
-            gcStats   := system gcStats.
+            endGcStats   := system gcStats.
+            endCompTime := system totalCompilationTime.
 
-            bench name print. ': GC count:     ' print. ((gcStats) at: 1) print. 'n' println.
-            bench name print. ': GC time:      ' print. ((gcStats) at: 2) print. 'ms' println.
-            bench name print. ': Compile time: ' print. system compilerTime print. 'ms' println.
+            bench name print. ': GC count:     ' print. (((endGcStats) at: 1) - ((startGcStats) at: 1)) print. 'n' println.
+            bench name print. ': GC time:      ' print. (((endGcStats) at: 2) - ((startGcStats) at: 2)) print. 'ms' println.
+            bench name print. ': Compile time: ' print. (endCompTime - startCompTime) print. 'ms' println.
 
             runTime := endTime - startTime.
             printAll ifTrue: [ self print: bench run: runTime ].

--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -118,18 +118,20 @@ BenchmarkHarness = (
             startGcStats := system gcStats.
             startCompTime := system totalCompilationTime.
             startTime := system ticks.
+
             (bench innerBenchmarkLoop: innerIterations) ifFalse: [
               self error: 'Benchmark failed with incorrect result'. ].
-            endTime   := system ticks.
-            endGcStats   := system gcStats.
+
+            endTime     := system ticks.
+            endGcStats  := system gcStats.
             endCompTime := system totalCompilationTime.
 
-            bench name print. ': GC count:     ' print. (((endGcStats) at: 1) - ((startGcStats) at: 1)) print. 'n' println.
-            bench name print. ': GC time:      ' print. (((endGcStats) at: 2) - ((startGcStats) at: 2)) print. 'ms' println.
-            bench name print. ': Compile time: ' print. (endCompTime - startCompTime) print. 'ms' println.
-
             runTime := endTime - startTime.
-            printAll ifTrue: [ self print: bench run: runTime ].
+            printAll ifTrue: [
+              bench name print. ': GC count:     ' print. (((endGcStats) at: 1) - ((startGcStats) at: 1)) print. 'n' println.
+              bench name print. ': GC time:      ' print. (((endGcStats) at: 2) - ((startGcStats) at: 2)) print. 'ms' println.
+              bench name print. ': Compile time: ' print. (endCompTime - startCompTime) print. 'ms' println.
+              self print: bench run: runTime ].
         
             total := total + runTime.
             i := i + 1.
@@ -154,8 +156,7 @@ BenchmarkHarness = (
      
     print: bench run: runTime = (
         bench name print.
-        ': iterations=1' print.
-        ' runtime: ' print.
+        ': iterations=1 runtime: ' print.
         runTime print.
         'us' println
     )

--- a/Smalltalk/System.som
+++ b/Smalltalk/System.som
@@ -88,6 +88,9 @@ System = (
 
     "Force Garbage Collection"
     fullGC = primitive
+    
+    gcStats = primitive
+    compilerTime = primitive
 
     ----------------------------------
 

--- a/Smalltalk/System.som
+++ b/Smalltalk/System.som
@@ -89,8 +89,11 @@ System = (
     "Force Garbage Collection"
     fullGC = primitive
     
-    gcStats = primitive
-    compilerTime = primitive
+    "To be implemented by SOM implementations that gather such statistics."
+    gcStats = ( ^ #(
+        0 "Total number of GCs"
+        0 "Estimated total GC time in milliseconds") )  
+    totalCompilationTime = ( ^ 0 "Estimated total compilation time in milliseconds" )
 
     ----------------------------------
 

--- a/SomSom/src/primitives/SystemPrimitives.som
+++ b/SomSom/src/primitives/SystemPrimitives.som
@@ -88,10 +88,10 @@ SystemPrimitives = Primitives (
         frame push: arr ]).
 
     self installInstancePrimitive: (
-      SPrimitive new: 'compilerTime' in: universe with: [:frame :interp |
+      SPrimitive new: 'totalCompilationTime' in: universe with: [:frame :interp |
         | cTime |
         frame pop. "ignore"
-        cTime := system compilerTime.
+        cTime := system totalCompilationTime.
         frame push: (universe newInteger: cTime) ]).
 
     self installInstancePrimitive: (

--- a/SomSom/src/primitives/SystemPrimitives.som
+++ b/SomSom/src/primitives/SystemPrimitives.som
@@ -77,6 +77,24 @@ SystemPrimitives = Primitives (
         frame push: (universe newInteger: ticks) ]).
 
     self installInstancePrimitive: (
+      SPrimitive new: 'gcStats' in: universe with: [:frame :interp |
+        | gcStats arr |
+        frame pop. "ignore"
+        gcStats := system gcStats.
+        arr := universe newArray: 2.
+        arr indexableField: 1 put: (universe newInteger: (gcStats at: 1)).
+        arr indexableField: 2 put: (universe newInteger: (gcStats at: 2)).
+        
+        frame push: arr ]).
+
+    self installInstancePrimitive: (
+      SPrimitive new: 'compilerTime' in: universe with: [:frame :interp |
+        | cTime |
+        frame pop. "ignore"
+        cTime := system compilerTime.
+        frame push: (universe newInteger: cTime) ]).
+
+    self installInstancePrimitive: (
       SPrimitive new: 'fullGC' in: universe with: [:frame :interp |
         frame pop. "ignore"
         system fullGC.


### PR DESCRIPTION
This PR adds the following methods to the `System` class:
 - `#gcStats`: returns an array with GC count and total GC time in milliseconds
 - `#totalCompilationTime`: returns an integer with the total time spend compiling

SOM implementations are free to replace these methods from within the implementation to provide the desired details.