### PR TITLE
Add allocated bytes to gcStats

### DIFF
--- a/Examples/Benchmarks/BenchmarkHarness.som
+++ b/Examples/Benchmarks/BenchmarkHarness.som
@@ -130,6 +130,7 @@ BenchmarkHarness = (
             printAll ifTrue: [
               bench name print. ': GC count:     ' print. (((endGcStats) at: 1) - ((startGcStats) at: 1)) print. 'n' println.
               bench name print. ': GC time:      ' print. (((endGcStats) at: 2) - ((startGcStats) at: 2)) print. 'ms' println.
+              bench name print. ': Allocated:    ' print. (((endGcStats) at: 3) - ((startGcStats) at: 3)) print. 'bytes' println.
               bench name print. ': Compile time: ' print. (endCompTime - startCompTime) print. 'ms' println.
               self print: bench run: runTime ].
         

--- a/Smalltalk/System.som
+++ b/Smalltalk/System.som
@@ -92,7 +92,8 @@ System = (
     "To be implemented by SOM implementations that gather such statistics."
     gcStats = ( ^ #(
         0 "Total number of GCs"
-        0 "Estimated total GC time in milliseconds") )  
+        0 "Estimated total GC time in milliseconds"
+        0 "Approximate number of allocated bytes of current thread") )  
     totalCompilationTime = ( ^ 0 "Estimated total compilation time in milliseconds" )
 
     ----------------------------------

--- a/SomSom/src/primitives/SystemPrimitives.som
+++ b/SomSom/src/primitives/SystemPrimitives.som
@@ -81,10 +81,11 @@ SystemPrimitives = Primitives (
         | gcStats arr |
         frame pop. "ignore"
         gcStats := system gcStats.
-        arr := universe newArray: 2.
+        arr := universe newArray: 3.
         arr indexableField: 1 put: (universe newInteger: (gcStats at: 1)).
         arr indexableField: 2 put: (universe newInteger: (gcStats at: 2)).
-        
+        arr indexableField: 3 put: (universe newInteger: (gcStats at: 3)).
+
         frame push: arr ]).
 
     self installInstancePrimitive: (


### PR DESCRIPTION
This extends the `System>>#gcStats` primitive to include an approximate number of allocated bytes for the current thread.

On Java, it is implemented using [ThreadMXBean.getCurrentThreadAllocatedBytes()](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/ThreadMXBean.html#getCurrentThreadAllocatedBytes()).

An implementation is free to return just `0` or `-1` if data is not available.
The semantics are ideally close to the Java ones, though, then again, they differ between GC implementations on HotSpot and Substrate, too...
So, it's a best effort API...