### PR TITLE
Add test for parsing of operator symbols

### DIFF
--- a/SomSom/src/compiler/Parser.som
+++ b/SomSom/src/compiler/Parser.som
@@ -196,13 +196,9 @@ Parser = (
     | s |
     s := text.
 
-    (self accept: #or) or: [
-    (self accept: #comma) or: [
-    (self accept: #minus) or: [
-    (self accept: #equal) or: [
     (self accept: #operatorSequence) or: [
     (self acceptOneOf: Parser singleOpSyms) or: [
-        self expect: #none ] ] ] ] ] ].
+        self expect: #none ] ].
 
     ^ universe symbolFor: s
   )
@@ -692,7 +688,7 @@ Parser = (
   singleOpSyms = (
     singleOpSyms == nil ifTrue: [
       singleOpSyms := #(#not #and #or #star #div #mod #plus #equal
-                        #more #less #comma #at #per #none) ].
+                        #more #less #comma #at #per #minus #none) ].
     ^ singleOpSyms
   )
 

--- a/TestSuite/SymbolTest.som
+++ b/TestSuite/SymbolTest.som
@@ -31,24 +31,41 @@ SymbolTest = TestCase (
     self assert: 'gunk' equals: 'gunk' asSymbol asString.
     self assert: 'oink' equals: #oink asString.
   )
-  
+
   testEquality = (
     self assert: #oink == #oink.
     self assert: #oink == 'oink' asSymbol.
     self assert: #oink =  #oink.
     self assert: #oink =  'oink' asSymbol.
-    
+
     self deny: #foo =  #fooo.
     self deny: #foo == #fooo.
-    
+
     self deny: #foo =  'foo'.
     self deny: #foo == 'fooo'.
     self deny: #foo == #foo asString.
   )
-  
+
   testSymbolIsString = (
     self assert: (#oink beginsWith: 'oink').
     self assert: 100 equals: #'100' asInteger.
     self assert: String equals: #foo class superclass
+  )
+
+  testOperatorSymbols = (
+    self assert: #~ equals: '~' asSymbol.
+    self assert: #& equals: '&' asSymbol.
+    self assert: #| equals: '|' asSymbol.
+    self assert: #* equals: '*' asSymbol.
+    self assert: #/ equals: '/' asSymbol.
+    self assert: #\ equals: '\\' asSymbol.
+    self assert: #+ equals: '+' asSymbol.
+    self assert: #= equals: '=' asSymbol.
+    self assert: #> equals: '>' asSymbol.
+    self assert: #< equals: '<' asSymbol.
+    self assert: #, equals: ',' asSymbol.
+    self assert: #@ equals: '@' asSymbol.
+    self assert: #% equals: '%' asSymbol.
+    self assert: #- equals: '-' asSymbol.
   )
 )


### PR DESCRIPTION
Added a test for https://github.com/SOM-st/som-java/issues/30

The spec has the operators here: https://github.com/SOM-st/SOM/blob/master/specification/SOM.g4#L178-L194

Parsers have issues with the `#-` symbol.

The current status for the SOM implementations is:

| Status 	| SOM        	| PR                                           	|
|:------:	|------------	|----------------------------------------------	|
|  :white_check_mark: | SOM (java) 	| https://github.com/SOM-st/som-java/pull/31   	|
|  :white_check_mark: | TruffleSOM 	| https://github.com/SOM-st/TruffleSOM/pull/167	|
|         	| SOM++      	|                                              	|
|       	| CSOM       	|                                              	|
|   | PySOM      	|  	|
|        	| JsSOM      	|                                              	|
|        	| SOM-RS     	|                                              	|
|        	| ykSOM      	|                                              	|