### PR TITLE
The #= on Symbol and String should be symmetric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout SOM Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout SOM VM Repository
         if: matrix.som != 'spec'
@@ -82,7 +82,7 @@ jobs:
           export GITHUB_USER=${{ github.actor }}
           export PR_TARGET_USER=${{ github.repository_owner }}
           export REPO=${{ matrix.repo }}
-          
+
           GIT_CMDS=(
             "git clone --branch $BRANCH_NAME --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm"
           )
@@ -93,12 +93,12 @@ jobs:
               "git clone --branch ${{ github.head_ref }} --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm"
             )
           fi
-          
+
           GIT_CMDS+=(
             "git clone --depth 1 https://github.com/$GITHUB_USER/$REPO som-vm"
             "git clone --depth 1 https://github.com/$PR_TARGET_USER/$REPO som-vm"
           )
-          
+
           for ((i = 0; i < ${#GIT_CMDS[@]}; i++))
           do
             echo ""
@@ -124,19 +124,19 @@ jobs:
         run: |
           cd specification
           make test
-      
+
       - name: Check Whether Basic Interpreter Tests are Up to Date
         if: ${{ matrix.som == 'spec' }}
         run: |
           ./TestSuite/BasicInterpreterTests/number-of-tests.sh
-      
+
       - name: Build SOM VM
         if: ${{ matrix.som != 'spec' }}
         run: |
           export ST_DIR=`pwd`/Smalltalk
           cd som-vm
           git --no-pager log -n 1
-      
+
           echo Build ${{ matrix.repo }}
           ${{ matrix.build }}
 
@@ -151,7 +151,7 @@ jobs:
           else
             export SOM_TESTS="${{ matrix.som-tests }}"
           fi
-      
+
           echo "${{ matrix.som }} $SOM_TESTS"
           eval "${{ matrix.som }} $SOM_TESTS"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
           - name: TruffleSOM
             repo: TruffleSOM.git
             build: |
-              export JAVA_HOME=$JAVA_HOME_8_X64
+              export JAVA_HOME=$JAVA_HOME_17_X64
               ant jar
-            som: "JAVA_HOME=$JAVA_HOME_8_X64 ./som -G"
+            som: "JAVA_HOME=$JAVA_HOME_17_X64 ./som -G"
             not-up-to-date: false
 
           - name: Specification Tests

--- a/Examples/Benchmarks/TestSuite/Symbol2Test.som
+++ b/Examples/Benchmarks/TestSuite/Symbol2Test.som
@@ -31,21 +31,21 @@ Symbol2Test = TestCase (
     self assert: 'gunk' equals: 'gunk' asSymbol asString.
     self assert: 'oink' equals: #oink asString.
   )
-  
+
   testEquality = (
     self assert: #oink == #oink.
     self assert: #oink == 'oink' asSymbol.
     self assert: #oink =  #oink.
     self assert: #oink =  'oink' asSymbol.
-    
+
     self deny: #foo =  #fooo.
     self deny: #foo == #fooo.
-    
-    self deny: #foo =  'foo'.
+
+    self assert: #foo =  'foo'.
     self deny: #foo == 'fooo'.
     self deny: #foo == #foo asString.
   )
-  
+
   testSymbolIsString = (
     self assert: (#oink beginsWith: 'oink').
     self assert: 100 equals: #'100' asInteger.

--- a/Examples/Benchmarks/TestSuite/Symbol3Test.som
+++ b/Examples/Benchmarks/TestSuite/Symbol3Test.som
@@ -31,21 +31,21 @@ Symbol3Test = TestCase (
     self assert: 'gunk' equals: 'gunk' asSymbol asString.
     self assert: 'oink' equals: #oink asString.
   )
-  
+
   testEquality = (
     self assert: #oink == #oink.
     self assert: #oink == 'oink' asSymbol.
     self assert: #oink =  #oink.
     self assert: #oink =  'oink' asSymbol.
-    
+
     self deny: #foo =  #fooo.
     self deny: #foo == #fooo.
-    
-    self deny: #foo =  'foo'.
+
+    self assert: #foo =  'foo'.
     self deny: #foo == 'fooo'.
     self deny: #foo == #foo asString.
   )
-  
+
   testSymbolIsString = (
     self assert: (#oink beginsWith: 'oink').
     self assert: 100 equals: #'100' asInteger.

--- a/Examples/Benchmarks/TestSuite/Symbol4Test.som
+++ b/Examples/Benchmarks/TestSuite/Symbol4Test.som
@@ -31,21 +31,21 @@ Symbol4Test = TestCase (
     self assert: 'gunk' equals: 'gunk' asSymbol asString.
     self assert: 'oink' equals: #oink asString.
   )
-  
+
   testEquality = (
     self assert: #oink == #oink.
     self assert: #oink == 'oink' asSymbol.
     self assert: #oink =  #oink.
     self assert: #oink =  'oink' asSymbol.
-    
+
     self deny: #foo =  #fooo.
     self deny: #foo == #fooo.
-    
-    self deny: #foo =  'foo'.
+
+    self assert: #foo =  'foo'.
     self deny: #foo == 'fooo'.
     self deny: #foo == #foo asString.
   )
-  
+
   testSymbolIsString = (
     self assert: (#oink beginsWith: 'oink').
     self assert: 100 equals: #'100' asInteger.

--- a/Examples/Benchmarks/TestSuite/Symbol5Test.som
+++ b/Examples/Benchmarks/TestSuite/Symbol5Test.som
@@ -31,21 +31,21 @@ Symbol5Test = TestCase (
     self assert: 'gunk' equals: 'gunk' asSymbol asString.
     self assert: 'oink' equals: #oink asString.
   )
-  
+
   testEquality = (
     self assert: #oink == #oink.
     self assert: #oink == 'oink' asSymbol.
     self assert: #oink =  #oink.
     self assert: #oink =  'oink' asSymbol.
-    
+
     self deny: #foo =  #fooo.
     self deny: #foo == #fooo.
-    
-    self deny: #foo =  'foo'.
+
+    self assert: #foo =  'foo'.
     self deny: #foo == 'fooo'.
     self deny: #foo == #foo asString.
   )
-  
+
   testSymbolIsString = (
     self assert: (#oink beginsWith: 'oink').
     self assert: 100 equals: #'100' asInteger.

--- a/Examples/Benchmarks/TestSuite/SymbolTest.som
+++ b/Examples/Benchmarks/TestSuite/SymbolTest.som
@@ -31,21 +31,21 @@ SymbolTest = TestCase (
     self assert: 'gunk' equals: 'gunk' asSymbol asString.
     self assert: 'oink' equals: #oink asString.
   )
-  
+
   testEquality = (
     self assert: #oink == #oink.
     self assert: #oink == 'oink' asSymbol.
     self assert: #oink =  #oink.
     self assert: #oink =  'oink' asSymbol.
-    
+
     self deny: #foo =  #fooo.
     self deny: #foo == #fooo.
-    
-    self deny: #foo =  'foo'.
+
+    self assert: #foo =  'foo'.
     self deny: #foo == 'fooo'.
     self deny: #foo == #foo asString.
   )
-  
+
   testSymbolIsString = (
     self assert: (#oink beginsWith: 'oink').
     self assert: 100 equals: #'100' asInteger.

--- a/Smalltalk/Symbol.som
+++ b/Smalltalk/Symbol.som
@@ -25,11 +25,13 @@ THE SOFTWARE.
 
 Symbol = String (
 
+    concatenate: argument = ( ^ (super concatenate: argument) asSymbol )
+
     "Converting"
     asString = primitive
     asSymbol = ( ^self )
-    
+
     "Printing"
     print    = ( '#' print. super print )
-    
+
 )

--- a/SomSom/src/primitives/SymbolPrimitives.som
+++ b/SomSom/src/primitives/SymbolPrimitives.som
@@ -7,14 +7,6 @@ SymbolPrimitives = Primitives (
         rcvr := frame pop.
 
         frame push: (universe newString: rcvr string) ]).
-
-    self installInstancePrimitive: (
-      SPrimitive new: '=' in: universe with: [:frame :interp |
-        | rcvr arg |
-        arg := frame pop.
-        rcvr := frame pop.
-
-        frame push: (self somBool: rcvr == arg) ] ) dontWarn: true.
   )
 
   ----

--- a/TestSuite/SymbolTest.som
+++ b/TestSuite/SymbolTest.som
@@ -41,7 +41,7 @@ SymbolTest = TestCase (
     self deny: #foo =  #fooo.
     self deny: #foo == #fooo.
 
-    self deny: #foo =  'foo'.
+    self assert: #foo = 'foo'.
     self deny: #foo == 'fooo'.
     self deny: #foo == #foo asString.
   )

--- a/TestSuite/SymbolTest.som
+++ b/TestSuite/SymbolTest.som
@@ -27,6 +27,11 @@ THE SOFTWARE.
 
 SymbolTest = TestCase (
 
+  testConcatenation = (
+    self assert: #a + #b is: #ab.
+    self assert: #a + 'b' is: #ab.
+  )
+
   testConversion = (
     self assert: 'gunk' equals: 'gunk' asSymbol asString.
     self assert: 'oink' equals: #oink asString.


### PR DESCRIPTION
- it’s only defined in String
- there’s no hint that it should behave differently in Symbol which is a subclass
- so, we really should just consider the string content when comparing #foobar = ‘foobar’

Resolves https://github.com/SOM-st/SOM/issues/105

| Status 	| SOM        	| PR                                           	|
|:------:	|------------	|----------------------------------------------	|
| :white_check_mark: | SOM (java) 	| https://github.com/SOM-st/som-java/pull/32   	|
|  | TruffleSOM 	| https://github.com/SOM-st/TruffleSOM/pull/	|
| :white_check_mark: | PySOM      	| https://github.com/SOM-st/PySOM/pull/50 |
| :white_check_mark: | JsSOM      	| https://github.com/SOM-st/JsSOM/pull/14 |
| :white_check_mark: | SOM-RS     	| https://github.com/Hirevo/som-rs/pull/26 |
|       	| CSOM       	| (needs other fixes) |
|         	| SOM++      	| (needs other fixes) |
|        	| ykSOM      	| https://github.com/softdevteam/yksom/pull/|