### PR TITLE
Add tests to check that boolean messages short circuit execution

### DIFF
--- a/TestSuite/BooleanTest.som
+++ b/TestSuite/BooleanTest.som
@@ -4,50 +4,50 @@ BooleanTest = TestCase (
       | b1 b2 |
       b1 := false.
       b2 := false.
-      
+
       true ifTrue: [ b1 := true ] ifFalse: [ b2 := true ].
       self assert: b1.
       self deny: b2.
-      
+
       b1 := false.
       b2 := false.
       false ifTrue: [ b1 := true ] ifFalse: [ b2 := true ].
       self assert: b2.
       self deny: b1.
     )
-    
+
     testIfTrue = (
       | b |
       b := false.
-      
+
       true ifTrue: [ b := true ].
       self assert: b.
-      
+
       b := false.
       false ifTrue: [ b := true ].
       self deny: b.
     )
-    
+
     testIfTrueWithValueBlock = (
       | b block |
       b := false.
       block := [ b := true ].
-      
+
       true ifTrue: block.
       self assert: b.
-      
+
       b := false.
       false ifTrue: block.
       self deny: b.
-    ) 
-    
+    )
+
     testIfFalse = (
       | b |
       b := false.
-      
+
       true ifFalse: [ b := true ].
       self deny: b.
-      
+
       b := false.
       false ifFalse: [ b := true ].
       self assert: b.
@@ -57,15 +57,15 @@ BooleanTest = TestCase (
       | b block |
       b := false.
       block := [ b := true ].
-      
+
       true ifFalse: block.
       self deny: b.
-      
+
       b := false.
       false ifFalse: block.
       self assert: b.
     )
-    
+
     testNot = (
       self deny: true not.
       self assert: false not.
@@ -75,67 +75,67 @@ BooleanTest = TestCase (
     andBoolTrueFalse  = ( ^ true  and: [ false ] )
     andBoolFalseTrue  = ( ^ false and: [ true  ] )
     andBoolFalseFalse = ( ^ false and: [ false ] )
-    
+
     testAnd = (
       self assert: self andBoolTrueTrue.
       self deny:   self andBoolTrueFalse.
       self deny:   self andBoolFalseTrue.
       self deny:   self andBoolFalseFalse.
     )
-    
+
     ampBoolTrueTrue   = ( ^ true  && [ true  ] )
     ampBoolTrueFalse  = ( ^ true  && [ false ] )
     ampBoolFalseTrue  = ( ^ false && [ true  ] )
     ampBoolFalseFalse = ( ^ false && [ false ] )
-    
+
     testAmp = (
       self assert: self ampBoolTrueTrue.
       self deny:   self ampBoolTrueFalse.
       self deny:   self ampBoolFalseTrue.
       self deny:   self ampBoolFalseFalse.
     )
-    
+
     orBoolTrueTrue   = ( ^ true  or: [ true  ] )
     orBoolTrueFalse  = ( ^ true  or: [ false ] )
     orBoolFalseTrue  = ( ^ false or: [ true  ] )
     orBoolFalseFalse = ( ^ false or: [ false ] )
-    
+
     testOr = (
       self assert: self orBoolTrueTrue.
       self assert: self orBoolTrueFalse.
       self assert: self orBoolFalseTrue.
       self deny:   self orBoolFalseFalse.
     )
-    
+
     pipeBoolTrueTrue   = ( ^ true  || [ true  ] )
     pipeBoolTrueFalse  = ( ^ true  || [ false ] )
     pipeBoolFalseTrue  = ( ^ false || [ true  ] )
     pipeBoolFalseFalse = ( ^ false || [ false ] )
-    
+
     testPipe = (
       self assert: self pipeBoolTrueTrue.
       self assert: self pipeBoolTrueFalse.
       self assert: self pipeBoolFalseTrue.
       self deny:   self pipeBoolFalseFalse.
     )
-    
+
     testAsString = (
       self assert: 'true'  equals: true asString.
       self assert: 'false' equals: false asString.
     )
-    
+
     testIfNil = (
       self assert: (nil ifNil: [ true ]).
       self deny:   (nil ifNil: [ false ]).
-      
+
       self assert: (self ifNil: [ #notExec ]) is: self.
       self assert: (self ifNil: [ #notExec ]) is: self.
     )
-    
+
     testIfNotNil = (
       self assert: (self ifNotNil: [ true ]).
       self deny:   (self ifNotNil: [ false ]).
-      
+
       self assert: (nil ifNotNil: [ #notExec ]) is: nil.
       self assert: (nil ifNotNil: [ #notExec ]) is: nil.
     )

--- a/TestSuite/BooleanTest.som
+++ b/TestSuite/BooleanTest.som
@@ -119,6 +119,39 @@ BooleanTest = TestCase (
       self deny:   self pipeBoolFalseFalse.
     )
 
+    testBlockSideEffectsOnLogicOps = (
+      | changed unused |
+      changed := false.
+
+      "#and:"
+      unused := true and: [ changed := #case1. true ].
+      self assert: changed is: #case1.
+
+      unused := false and: [ changed := #no. true ].
+      self assert: changed is: #case1.
+
+      "&&"
+      unused := true && [ changed := #case2. true ].
+      self assert: changed is: #case2.
+
+      unused := false && [ changed := #no. true ].
+      self assert: changed is: #case2.
+
+      "#or:"
+      unused := true or: [ changed := #no. true ].
+      self assert: changed is: #case2.
+
+      unused := false or: [ changed := #case3. true ].
+      self assert: changed is: #case3.
+
+      "||"
+      unused := true || [ changed := #no. true ].
+      self assert: changed is: #case3.
+
+      unused := false || [ changed := #case4. true ].
+      self assert: changed is: #case4.
+    )
+
     testAsString = (
       self assert: 'true'  equals: true asString.
       self assert: 'false' equals: false asString.


### PR DESCRIPTION
A boolean message does not need to execute the given block when it is already true based on the receiver.

This resolves https://github.com/SOM-st/SOM/issues/108