### PR TITLE
Generalize the script for generating copies of the unit test suite for benchmarking

### DIFF
--- a/Examples/Benchmarks/TestSuite/.gitignore
+++ b/Examples/Benchmarks/TestSuite/.gitignore
@@ -1,0 +1,2 @@
+*Test.som
+Test*.som

--- a/Examples/Benchmarks/TestSuite/Hash4Test.som
+++ b/Examples/Benchmarks/TestSuite/Hash4Test.som
@@ -43,7 +43,7 @@ Hash4Test = TestCase (
     ht at: 1 put: 2.
     t := Hashtable new.
     ht at: Hashtable put: t.
-
+    
     self assert: (ht containsValue: 'b') description: 'needs to contain "b"'.
     self assert: (ht containsValue: 'd') description: 'needs to contain "d"'.
     self assert: (ht containsValue: 2)   description: 'needs to contain "2"'.

--- a/Examples/Benchmarks/TestSuite/Test.som
+++ b/Examples/Benchmarks/TestSuite/Test.som
@@ -23,9 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-Test = Benchmark (
-    | failOnUnsupportedOptionals |
-
+Test = TestCommon (
     tests = ( "Now ordered by alphabetical order to improve maintainability"
         ^ EmptyTest,
           SpecialSelectorsTest,
@@ -150,61 +148,7 @@ Test = Benchmark (
           Vector5Test
     )
     
-    oneTimeSetup = (
-      "Load all Tests. We don't really want to benchmark the parser."
-      self tests
-    )
-
-    runAllSuites = (
-      | totalTestNum successfulTestNum unsupportedTestNum totalAssertionNum arr |
-      totalTestNum := 0.
-      unsupportedTestNum := 0.
-      successfulTestNum := 0.
-      totalAssertionNum := 0.
-
-      self tests do: [ :test |
-        | runner |
-        runner := TestRunner new.
-        runner initializeOn: test.
-        runner runAllTests.
-
-        totalTestNum       := totalTestNum + runner expectedPasses.
-        unsupportedTestNum := unsupportedTestNum + runner actualUnsupported.
-        successfulTestNum  := successfulTestNum + runner actualPasses.
-        totalAssertionNum  := totalAssertionNum + runner numAsserts.
-      ].
-
-      arr := Array new: 4.
-      arr at: 1 put: totalTestNum.
-      arr at: 2 put: unsupportedTestNum.
-      arr at: 3 put: successfulTestNum.
-      arr at: 4 put: totalAssertionNum.
-      ^ arr
-    )
-
-    runOneSuite: name = (
-      | testName runner |
-      testName := name.
-      (testName endsWith: 'Test') ifFalse: [
-        testName := testName + 'Test'].
-
-      runner := TestRunner new.
-      runner initializeOn: (system resolve: testName asSymbol).
-      runner run.
-      runner hasFailures ifTrue: [system exit: 1]
-    )
-    
-    benchmark = (
-        failOnUnsupportedOptionals := false.
-        ^ self runAllSuites
-    )
-    
-    verifyResult: result = (
-      "result do: [:e | e println ]."
-      ^ (result at: 1) = 950 and: [
-          (result at: 2) = 0 and: [
-            (result at: 3) = 945 and: [
-              (result at: 4) = 4960
-        ] ] ]
+    numExecs = (
+    ^ 5
     )
 )

--- a/Examples/Benchmarks/TestSuite/TestCommon.som
+++ b/Examples/Benchmarks/TestSuite/TestCommon.som
@@ -1,0 +1,94 @@
+"
+
+$Id: TestHarness.som 30 2009-07-31 12:20:25Z michael.haupt $
+
+Copyright (c) 2001-2013 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+TestCommon = Benchmark (
+    | failOnUnsupportedOptionals |
+
+    tests = ( "Now ordered by alphabetical order to improve maintainability"
+        self error: 'Implement in subclass'
+    )
+
+    numExecs = (
+      self error: 'Implement in subclass and return the number of times a test is executed'
+    )
+    
+    oneTimeSetup = (
+      "Load all Tests. We don't really want to benchmark the parser."
+      self tests
+    )
+
+    runAllSuites = (
+      | totalTestNum successfulTestNum unsupportedTestNum totalAssertionNum arr |
+      totalTestNum := 0.
+      unsupportedTestNum := 0.
+      successfulTestNum := 0.
+      totalAssertionNum := 0.
+
+      self tests do: [ :test |
+        | runner |
+        runner := TestRunner new.
+        runner initializeOn: test.
+        runner runAllTests.
+
+        totalTestNum       := totalTestNum + runner expectedPasses.
+        unsupportedTestNum := unsupportedTestNum + runner actualUnsupported.
+        successfulTestNum  := successfulTestNum + runner actualPasses.
+        totalAssertionNum  := totalAssertionNum + runner numAsserts.
+      ].
+
+      arr := Array new: 4.
+      arr at: 1 put: totalTestNum.
+      arr at: 2 put: unsupportedTestNum.
+      arr at: 3 put: successfulTestNum.
+      arr at: 4 put: totalAssertionNum.
+      ^ arr
+    )
+
+    runOneSuite: name = (
+      | testName runner |
+      testName := name.
+      (testName endsWith: 'Test') ifFalse: [
+        testName := testName + 'Test'].
+
+      runner := TestRunner new.
+      runner initializeOn: (system resolve: testName asSymbol).
+      runner run.
+      runner hasFailures ifTrue: [system exit: 1]
+    )
+    
+    benchmark = (
+        failOnUnsupportedOptionals := false.
+        ^ self runAllSuites
+    )
+    
+    verifyResult: result = (
+      "result do: [:e | e println ]."
+      ^ (result at: 1) = (190 * self numExecs) and: [
+          (result at: 2) = (0 * self numExecs) and: [
+            (result at: 3) = (189 * self numExecs) and: [
+              (result at: 4) = (992 * self numExecs)
+        ] ] ]
+    )
+)

--- a/Examples/Benchmarks/TestSuite/TestGC.som
+++ b/Examples/Benchmarks/TestSuite/TestGC.som
@@ -20,9 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-TestGC = Benchmark (
-    | failOnUnsupportedOptionals |
-
+TestGC = TestGCCommon (
     tests = ( "Now ordered by alphabetical order to improve maintainability"
         ^ EmptyTest,
           SpecialSelectorsTest,
@@ -147,56 +145,7 @@ TestGC = Benchmark (
           Vector5Test
     )
     
-    oneTimeSetup = (
-      "Load all Tests. We don't really want to benchmark the parser."
-      self tests
-    )
-
-    runAllSuites = (
-      | totalTestNum successfulTestNum unsupportedTestNum totalAssertionNum arr |
-      totalTestNum := 0.
-      unsupportedTestNum := 0.
-      successfulTestNum := 0.
-      totalAssertionNum := 0.
-
-      self tests do: [ :test |
-        | runner |
-        runner := TestRunner new.
-        runner initializeOn: test.
-        runner runAllTests.
-
-        totalTestNum       := totalTestNum + runner expectedPasses.
-        unsupportedTestNum := unsupportedTestNum + runner actualUnsupported.
-        successfulTestNum  := successfulTestNum + runner actualPasses.
-        totalAssertionNum  := totalAssertionNum + runner numAsserts.
-      ].
-
-      arr := Array new: 4.
-      arr at: 1 put: totalTestNum.
-      arr at: 2 put: unsupportedTestNum.
-      arr at: 3 put: successfulTestNum.
-      arr at: 4 put: totalAssertionNum.
-      ^ arr
-    )
-
-    runOneSuite: name = (
-      | testName runner |
-      testName := name.
-      (testName endsWith: 'Test') ifFalse: [
-        testName := testName + 'Test'].
-
-      runner := TestRunner new.
-      runner initializeOn: (system resolve: testName asSymbol).
-      runner run.
-      runner hasFailures ifTrue: [system exit: 1]
-    )
-    
     benchmark = (
       ^ system fullGC
-    )
-    
-    verifyResult: result = (
-      "We expect the GC to actually promise us that it did work"
-      ^ result
     )
 )

--- a/Examples/Benchmarks/TestSuite/TestGCCommon.som
+++ b/Examples/Benchmarks/TestSuite/TestGCCommon.som
@@ -1,0 +1,82 @@
+"
+Copyright (c) 2021 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+TestGCCommon = Benchmark (
+    | failOnUnsupportedOptionals |
+
+    tests = ( "Now ordered by alphabetical order to improve maintainability"
+        self error: 'Implement in subclass'
+    )
+    
+    oneTimeSetup = (
+      "Load all Tests. We don't really want to benchmark the parser."
+      self tests
+    )
+
+    runAllSuites = (
+      | totalTestNum successfulTestNum unsupportedTestNum totalAssertionNum arr |
+      totalTestNum := 0.
+      unsupportedTestNum := 0.
+      successfulTestNum := 0.
+      totalAssertionNum := 0.
+
+      self tests do: [ :test |
+        | runner |
+        runner := TestRunner new.
+        runner initializeOn: test.
+        runner runAllTests.
+
+        totalTestNum       := totalTestNum + runner expectedPasses.
+        unsupportedTestNum := unsupportedTestNum + runner actualUnsupported.
+        successfulTestNum  := successfulTestNum + runner actualPasses.
+        totalAssertionNum  := totalAssertionNum + runner numAsserts.
+      ].
+
+      arr := Array new: 4.
+      arr at: 1 put: totalTestNum.
+      arr at: 2 put: unsupportedTestNum.
+      arr at: 3 put: successfulTestNum.
+      arr at: 4 put: totalAssertionNum.
+      ^ arr
+    )
+
+    runOneSuite: name = (
+      | testName runner |
+      testName := name.
+      (testName endsWith: 'Test') ifFalse: [
+        testName := testName + 'Test'].
+
+      runner := TestRunner new.
+      runner initializeOn: (system resolve: testName asSymbol).
+      runner run.
+      runner hasFailures ifTrue: [system exit: 1]
+    )
+    
+    benchmark = (
+      ^ system fullGC
+    )
+    
+    verifyResult: result = (
+      "We expect the GC to actually promise us that it did work"
+      ^ result
+    )
+)

--- a/Examples/Benchmarks/TestSuite/duplicate-tests.sh
+++ b/Examples/Benchmarks/TestSuite/duplicate-tests.sh
@@ -1,32 +1,81 @@
 #!/bin/sh
-for i in $(seq 2 5)
+echo "Currently, we can only do up to 10 classes, because otherwise, we have too many literals in a single method"
+for i in $(seq 1 100)
 do
   echo $i
 
-  cp ArrayTest.som                 Array${i}Test.som
-  cp BlockTest.som                 Block${i}Test.som
-  cp BooleanTest.som               Boolean${i}Test.som
-  cp ClassLoadingTest.som          ClassLoading${i}Test.som
-  cp ClassStructureTest.som        ClassStructure${i}Test.som
-  cp ClosureTest.som               Closure${i}Test.som
-  cp CoercionTest.som              Coercion${i}Test.som
-  cp CompilerReturnTest.som        CompilerReturn${i}Test.som
-  cp DictionaryTest.som            Dictionary${i}Test.som
-  cp DoesNotUnderstandTest.som     DoesNotUnderstand${i}Test.som
-  cp DoubleTest.som                Double${i}Test.som
-  cp EmptyTest.som                 Empty${i}Test.som
-  cp GlobalTest.som                Global${i}Test.som
-  cp HashTest.som                  Hash${i}Test.som
-  cp IntegerTest.som               Integer${i}Test.som
-  cp PreliminaryTest.som           Preliminary${i}Test.som
-  cp ReflectionTest.som            Reflection${i}Test.som
-  cp SelfBlockTest.som             SelfBlock${i}Test.som
-  cp SetTest.som                   Set${i}Test.som
-  cp SpecialSelectorsTest.som      SpecialSelectors${i}Test.som
-  cp StringTest.som                String${i}Test.som
-  cp SuperTest.som                 Super${i}Test.som
-  cp SymbolTest.som                Symbol${i}Test.som
-  cp SystemTest.som                System${i}Test.som
-  cp VectorTest.som                Vector${i}Test.som
+  TESTS=("Array" "Block" "Boolean" "ClassLoading" "ClassStructure" "Closure" "Coercion"
+         "CompilerReturn" "Dictionary" "DoesNotUnderstand" "Double" "Empty" "Global"
+         "Hash" "Integer" "Preliminary" "Reflection" "SelfBlock" "Set" "SpecialSelectors"
+         "String"
+         "Super" "Symbol" "System" "Vector")
+  
+  for name in ${TESTS[@]}
+  do
+    cp "${name}Test.som" "${name}${i}Test.som"
+    sed -i '' "s/${name}Test =/${name}${i}Test =/g" "${name}${i}Test.som"
+  done
+
+  # Create TestGC${i}.som
+  TEST_GC_FILE="TestGC${i}.som"
+  TEST_GC_CLASS="TestGC${i}"
+
+  echo "${TEST_GC_CLASS} = TestGCCommon (" >  "${TEST_GC_FILE}"
+  echo "  tests = ("                       >> "${TEST_GC_FILE}"
+  echo "    | v |"                         >> "${TEST_GC_FILE}"
+  echo "    v := Vector new."              >> "${TEST_GC_FILE}"
+  for j in $(seq 1 "$i")
+  do
+    echo "    self tests${j}: v."          >> "${TEST_GC_FILE}"
+  done
+  echo "    ^ v"                           >> "${TEST_GC_FILE}"
+  echo "  )"                               >> "${TEST_GC_FILE}"
+  echo ""                                  >> "${TEST_GC_FILE}"
+
+  for j in $(seq 1 "$i")
+  do
+    echo "  tests${j}: v = ("              >> "${TEST_GC_FILE}"
+
+    for name in ${TESTS[@]}
+    do
+      echo "    v append: ${name}${j}Test.">> "${TEST_GC_FILE}"
+    done
+    echo "  )"                             >> "${TEST_GC_FILE}"
+    echo ""                                >> "${TEST_GC_FILE}"
+  done
+  echo ")"                                 >> "${TEST_GC_FILE}"
+
+  # Create Test${i}.som
+  TEST_FILE="Test${i}.som"
+  TEST_CLASS="Test${i}"
+
+  echo "${TEST_CLASS} = TestCommon ("      >  "${TEST_FILE}"
+  echo "  numExecs = ("                    >> "${TEST_FILE}"
+  echo "    ^ $i"                          >> "${TEST_FILE}"
+  echo "  )"                               >> "${TEST_FILE}"
+  echo ""                                  >> "${TEST_FILE}"
+  echo "  tests = ("                       >> "${TEST_FILE}"
+  echo "    | v |"                         >> "${TEST_FILE}"
+  echo "    v := Vector new."              >> "${TEST_FILE}"
+  for j in $(seq 1 "$i")
+  do
+    echo "    self tests${j}: v."          >> "${TEST_FILE}"
+  done
+  echo "    ^ v"                           >> "${TEST_FILE}"
+  echo "  )"                               >> "${TEST_FILE}"
+  echo ""                                  >> "${TEST_FILE}"
+
+  for j in $(seq 1 "$i")
+  do
+    echo "  tests${j}: v = ("              >> "${TEST_FILE}"
+
+    for name in ${TESTS[@]}
+    do
+      echo "    v append: ${name}${j}Test.">> "${TEST_FILE}"
+    done
+    echo "  )"                             >> "${TEST_FILE}"
+    echo ""                                >> "${TEST_FILE}"
+  done
+  echo ")"                                 >> "${TEST_FILE}"
 
 done


### PR DESCRIPTION
The script can now generate an arbitrary number of copies of the unit test suite.
We do not currently use it here, but it can be useful to quickly simulate code bases of varying size.

It should also make it trivial to update the test cases when needed by simply copying them from the actual unit tests.
Though, for the stability of benchmark results, we haven't updated them.

To create more copies, use `./duplicate-tests.sh`.