### PR TITLE
Fix error object not returned correctly

### DIFF
--- a/Smalltalk/Vector.som
+++ b/Smalltalk/Vector.som
@@ -78,7 +78,7 @@ Vector = (
     "Removing"
     remove = (
         | value |
-        self isEmpty ifTrue: [ self error: 'Vector: Attempting to remove the last element from an empty Vector' ].
+        self isEmpty ifTrue: [ ^ self error: 'Vector: Attempting to remove the last element from an empty Vector' ].
         last := last - 1.
         value := storage at: last.
         storage at: last put: nil.
@@ -158,7 +158,7 @@ Vector = (
     "DeltaBlue"
     removeFirst = (
         | value |
-        self isEmpty ifTrue: [ self error: 'Vector: Attempting to remove the first element from an empty Vector' ].
+        self isEmpty ifTrue: [ ^ self error: 'Vector: Attempting to remove the first element from an empty Vector' ].
         value := storage at: first.
         storage at: first put: nil.
         first := first + 1.

--- a/TestSuite/VectorSubclass.som
+++ b/TestSuite/VectorSubclass.som
@@ -1,0 +1,5 @@
+VectorSubclass = Vector (
+  error: string = (
+    ^ #error
+  )
+)

--- a/TestSuite/VectorTest.som
+++ b/TestSuite/VectorTest.som
@@ -103,6 +103,18 @@ VectorTest = TestCase (
       v remove ]
   )
 
+  testRemoveOnEmptyWithSubclass = (
+    | v |
+    v := VectorSubclass new.
+    self assert: #error is: v remove.
+  )
+
+  testRemoveFirstOnEmptyWithSubclass = (
+    | v |
+    v := VectorSubclass new.
+    self assert: #error is: v removeFirst.
+  )
+
   testContains = (
     self assert: (a contains: 'hello').
     self assert: (a contains: #world).


### PR DESCRIPTION
The result of the `#error:` method should be returned, otherwise overriding `#error:` is not very helpful.