### PR TITLE
Micro benchmarks for interpreter performance

### DIFF
--- a/Examples/Benchmarks/LanguageFeatures/LocalLoop.som
+++ b/Examples/Benchmarks/LanguageFeatures/LocalLoop.som
@@ -1,0 +1,76 @@
+"
+Copyright (c) 2024 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+"Microbenchmark: measure addition and access to local variables in inlined loop"
+LocalLoop = Benchmark (
+    benchmark = ( | counter iter |
+        counter := 0.
+        iter := 20000.
+
+        [ iter > 0 ] whileTrue: [
+          iter := iter - 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+
+        ].
+
+        ^ counter
+    )
+
+    verifyResult: result = (
+      ^ 600000 = result
+    )
+
+)

--- a/Examples/Benchmarks/LanguageFeatures/LocalLoopNop.som
+++ b/Examples/Benchmarks/LanguageFeatures/LocalLoopNop.som
@@ -1,0 +1,76 @@
+"
+Copyright (c) 2024 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+"Microbenchmark: measure access to local variable in inlined loop"
+LocalLoopNop = Benchmark (
+    benchmark = ( | counter iter |
+        counter := 0.
+        iter := 20000.
+
+        [ iter > 0 ] whileTrue: [
+          iter := iter - 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+
+        ].
+
+        ^ counter
+    )
+
+    verifyResult: result = (
+      ^ 0 = result
+    )
+
+)

--- a/Examples/Benchmarks/LanguageFeatures/LocalLoopStore.som
+++ b/Examples/Benchmarks/LanguageFeatures/LocalLoopStore.som
@@ -1,0 +1,76 @@
+"
+Copyright (c) 2024 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+"Microbenchmark: measure writing a constant to local variable in inlined loop"
+LocalLoopStore = Benchmark (
+    benchmark = ( | counter iter |
+        counter := 0.
+        iter := 20000.
+
+        [ iter > 0 ] whileTrue: [
+          iter := iter - 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+
+        ].
+
+        ^ counter
+    )
+
+    verifyResult: result = (
+      ^ 1 = result
+    )
+
+)

--- a/Examples/Benchmarks/LanguageFeatures/LoopTrivialDispatch.som
+++ b/Examples/Benchmarks/LanguageFeatures/LoopTrivialDispatch.som
@@ -1,0 +1,78 @@
+"
+Copyright (c) 2024 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+"Microbenchmark: measure dispatch of a trivial method in inlined loop"
+LoopTrivialDispatch = Benchmark (
+    trivial = ( ^ 1 )
+
+    benchmark = ( | counter iter |
+        counter := 0.
+        iter := 20000.
+
+        [ iter > 0 ] whileTrue: [
+          iter := iter - 1.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+
+        ].
+
+        ^ counter
+    )
+
+    verifyResult: result = (
+      ^ 0 = result
+    )
+
+)


### PR DESCRIPTION
This PR adds a few microbenchmarks to assess the performance of access operations to locals and trivial message sends.

These benchmarks are used to investigate the performance of the bytecode loops on different SOM interpreters.

By having the relevant operation under investigation repeated 30 explicitly in the body of the inlined while loop, I am relatively confident that the overall execution time of the benchmark should be dominated by exactly the bytecodes I am interested in.

Doing it only once, would result in more focus on the loop-related bytecodes, which was not the goal here.

@OctaveLarose, this may be interesting for you.