### PR TITLE
Add more microbenchmarks to assess interpreter performance

### DIFF
--- a/Examples/Benchmarks/Interpreter/ArgRead.som
+++ b/Examples/Benchmarks/Interpreter/ArgRead.som
@@ -20,55 +20,58 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
-        counter := 0.
+"Microbenchmark: reading a method argument"
+ArgRead = Benchmark (
+    benchmark = (
+      ^ self benchmark: 0
+    )
+
+    benchmark: counter = ( | iter |
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 0 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/ArrayReadConst.som
+++ b/Examples/Benchmarks/Interpreter/ArrayReadConst.som
@@ -20,55 +20,55 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
-        counter := 0.
+"Microbenchmark: measure reading an array at contant index"
+ArrayReadConst = Benchmark (
+    benchmark = ( | arr iter |
+        arr := #(42).
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
+          arr at: 1.
         ].
 
-        ^ counter
+        ^ arr at: 1
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 42 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/ArrayWriteConstConst.som
+++ b/Examples/Benchmarks/Interpreter/ArrayWriteConstConst.som
@@ -20,55 +20,55 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
-        counter := 0.
+"Microbenchmark: writing a constant to an array at contant index"
+ArrayWriteConstConst = Benchmark (
+    benchmark = ( | arr iter |
+        arr := #(42).
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
+          arr at: 1 put: 2.
         ].
 
-        ^ counter
+        ^ arr at: 1
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 2 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/BlockSend0ConstReturn.som
+++ b/Examples/Benchmarks/Interpreter/BlockSend0ConstReturn.som
@@ -20,55 +20,54 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
-        counter := 0.
+"Microbenchmark: activating a block that evaluates to constant" 
+BlockSend0ConstReturn = Benchmark (
+    benchmark = ( | iter |
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
+          [ 0 ] value.
         ].
 
-        ^ counter
+        ^ [ 0 ] value
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 0 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/Const.som
+++ b/Examples/Benchmarks/Interpreter/Const.som
@@ -20,55 +20,54 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
-        counter := 0.
+"Microbenchmark: reading a literal"
+Const = Benchmark (
+    benchmark = ( | iter |
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          42.
+          42.
+          42.
+          42.
+          42.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          42.
+          42.
+          42.
+          42.
+          42.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          42.
+          42.
+          42.
+          42.
+          42.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          42.
+          42.
+          42.
+          42.
+          42.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          42.
+          42.
+          42.
+          42.
+          42.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          42.
+          42.
+          42.
+          42.
+          42.
         ].
 
-        ^ counter
+        ^ 42
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 42 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/FieldConstWrite.som
+++ b/Examples/Benchmarks/Interpreter/FieldConstWrite.som
@@ -20,9 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
+"Microbenchmark: write a constant to field"
+FieldConstWrite = Benchmark (
+    | counter |
+
+    benchmark = ( | iter |
         counter := 0.
         iter := 20000.
 

--- a/Examples/Benchmarks/Interpreter/FieldRead.som
+++ b/Examples/Benchmarks/Interpreter/FieldRead.som
@@ -20,55 +20,57 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
+"Microbenchmark: read field"
+FieldRead = Benchmark (
+    | counter |
+
+    benchmark = ( | iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 0 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/FieldReadIncWrite.som
+++ b/Examples/Benchmarks/Interpreter/FieldReadIncWrite.som
@@ -20,55 +20,57 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
+"Microbenchmark: reading, adding 1, and writing to a field"
+FieldReadIncWrite = Benchmark (
+    | counter |
+
+    benchmark = ( | iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 600000 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/FieldReadWrite.som
+++ b/Examples/Benchmarks/Interpreter/FieldReadWrite.som
@@ -20,55 +20,57 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
+"Microbenchmark: read field and write to field"
+FieldReadWrite = Benchmark (
+    | counter |
+
+    benchmark = ( | iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 0 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/GlobalRead.som
+++ b/Examples/Benchmarks/Interpreter/GlobalRead.som
@@ -20,55 +20,54 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
-    benchmark = ( | counter iter |
-        counter := 0.
+"Microbenchmark: read global"
+GlobalRead = Benchmark (
+    benchmark = ( | iter |
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
+          GlobalRead.
         ].
 
-        ^ counter
+        ^ GlobalRead
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ GlobalRead == result
     )
 )

--- a/Examples/Benchmarks/Interpreter/LocalConstWrite.som
+++ b/Examples/Benchmarks/Interpreter/LocalConstWrite.som
@@ -20,57 +20,55 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: measure access to local variable in inlined loop"
-LocalLoopNop = Benchmark (
+"Microbenchmark: measure writing a constant to local variable in inlined loop"
+LocalConstWrite = Benchmark (
     benchmark = ( | counter iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
 
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
 
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
 
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
 
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
 
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-          counter := counter.
-
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
+          counter := 1.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 0 = result
+      ^ 1 = result
     )
-
 )

--- a/Examples/Benchmarks/Interpreter/LocalRead.som
+++ b/Examples/Benchmarks/Interpreter/LocalRead.som
@@ -20,55 +20,55 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
+"Microbenchmark: read local variable"
+LocalRead = Benchmark (
     benchmark = ( | counter iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter.
+          counter.
+          counter.
+          counter.
+          counter.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 0 = result
     )
 )

--- a/Examples/Benchmarks/Interpreter/LocalReadIncWrite.som
+++ b/Examples/Benchmarks/Interpreter/LocalReadIncWrite.som
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: measure addition and access to local variables in inlined loop"
+"Microbenchmark: reading, adding 1, and writing to a local"
 LocalReadIncWrite = Benchmark (
     benchmark = ( | counter iter |
         counter := 0.

--- a/Examples/Benchmarks/Interpreter/LocalReadIncWrite.som
+++ b/Examples/Benchmarks/Interpreter/LocalReadIncWrite.som
@@ -20,57 +20,55 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: measure writing a constant to local variable in inlined loop"
-LocalLoopStore = Benchmark (
+"Microbenchmark: measure addition and access to local variables in inlined loop"
+LocalReadIncWrite = Benchmark (
     benchmark = ( | counter iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
+          counter := counter + 1.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 600000 = result
     )
-
 )

--- a/Examples/Benchmarks/Interpreter/LocalReadWrite.som
+++ b/Examples/Benchmarks/Interpreter/LocalReadWrite.som
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: measure access to local variable in inlined loop"
+"Microbenchmark: read and write local"
 LocalReadWrite = Benchmark (
     benchmark = ( | counter iter |
         counter := 0.

--- a/Examples/Benchmarks/Interpreter/LocalReadWrite.som
+++ b/Examples/Benchmarks/Interpreter/LocalReadWrite.som
@@ -20,57 +20,55 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: measure addition and access to local variables in inlined loop"
-LocalLoop = Benchmark (
+"Microbenchmark: measure access to local variable in inlined loop"
+LocalReadWrite = Benchmark (
     benchmark = ( | counter iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
 
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-          counter := counter + 1.
-
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
+          counter := counter.
         ].
 
         ^ counter
     )
 
     verifyResult: result = (
-      ^ 600000 = result
+      ^ 0 = result
     )
-
 )

--- a/Examples/Benchmarks/Interpreter/SelfSend0.som
+++ b/Examples/Benchmarks/Interpreter/SelfSend0.som
@@ -21,7 +21,7 @@ THE SOFTWARE.
 "
 
 "Microbenchmark: measure dispatch of a trivial method in inlined loop"
-LoopTrivialDispatch = Benchmark (
+SelfSend0 = Benchmark (
     trivial = ( ^ 1 )
 
     benchmark = ( | counter iter |
@@ -65,7 +65,6 @@ LoopTrivialDispatch = Benchmark (
           self trivial.
           self trivial.
           self trivial.
-
         ].
 
         ^ counter
@@ -74,5 +73,4 @@ LoopTrivialDispatch = Benchmark (
     verifyResult: result = (
       ^ 0 = result
     )
-
 )

--- a/Examples/Benchmarks/Interpreter/SelfSend0.som
+++ b/Examples/Benchmarks/Interpreter/SelfSend0.som
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: measure dispatch of a trivial method in inlined loop"
+"Microbenchmark: self send message without argument"
 SelfSend0 = Benchmark (
     trivial = ( ^ 1 )
 

--- a/Examples/Benchmarks/Interpreter/SelfSend0BlockConstNonLocalReturn.som
+++ b/Examples/Benchmarks/Interpreter/SelfSend0BlockConstNonLocalReturn.som
@@ -20,55 +20,57 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 "
 
-"Microbenchmark: write constant to local"
-LocalConstWrite = Benchmark (
+"Microbenchmark: self send message, which returns nonlocally from an embedded block"
+SelfSend0BlockConstNonLocalReturn = Benchmark (
+    trivial = ( [ ^ 42 ] value )
+
     benchmark = ( | counter iter |
         counter := 0.
         iter := 20000.
 
         [ iter > 0 ] whileTrue: [
           iter := iter - 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
 
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
-          counter := 1.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
+          self trivial.
         ].
 
-        ^ counter
+        ^ self trivial.
     )
 
     verifyResult: result = (
-      ^ 1 = result
+      ^ 42 = result
     )
 )

--- a/Examples/Benchmarks/TestSuite/Vector2Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector2Test.som
@@ -54,7 +54,7 @@ Vector2Test = TestCase (
       self assert: 1 equals: v first ].
 
     1 to: 10 do: [:i |
-      self assert: 1 equals: v first.
+      self assert: i equals: v first.
       v removeFirst ]
   )
 
@@ -148,7 +148,7 @@ Vector2Test = TestCase (
     self assert: 1 equals: (arr at: 1).
     self assert: 2 equals: (arr at: 2).
   )
-  
+
   testAsSet = (
     | v set |
     v := Vector new.
@@ -157,38 +157,38 @@ Vector2Test = TestCase (
     v append: 3.
     v append: 4.
     self assert: 4 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
-    
+
     v append: 1.
     v append: 1.
     v append: 1.
-    
+
     self assert: 4 + 3 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
   )
-  
+
   testIsEmpty = (
     | v |
     v := Vector new.
     self assert: v isEmpty.
-    
+
     v append: 1.
     self deny: v isEmpty.
-    
+
     v removeFirst.
     self assert: v isEmpty.
-    
+
     v append: #ee.
     self deny: v isEmpty.
-    
+
     v removeFirst.
-    self assert: v isEmpty.    
+    self assert: v isEmpty.
   )
-  
+
   testRemoveObj = (
     | v |
     v := Vector new.
@@ -200,31 +200,31 @@ Vector2Test = TestCase (
     v append: #f.
     v append: #g.
     v append: #h.
-    
+
     self assert: 8 equals: v size.
-    
+
     self deny: (v remove: #aa).
     self assert: (v remove: #e).
     self assert: 7 equals: v size.
   )
-  
+
   testAppendComma = (
     | v |
     v := Vector new.
     v, #a.
     v, #b.
-    
+
     self assert: 2 equals: v size.
     self assert: (v contains: #a).
     self assert: (v contains: #b).
   )
-  
+
   testDoIndexes = (
     | i v |
     v := Vector new.
     v doIndexes: [:j |
       self assert: false ].
-    
+
     v appendAll: #(1 2 3 4 5).
     i := 1.
     v doIndexes: [:j |
@@ -233,7 +233,7 @@ Vector2Test = TestCase (
     ].
     self assert: 6 equals: i.
   )
-  
+
   testDo = (
     | i v |
     v := Vector new.

--- a/Examples/Benchmarks/TestSuite/Vector3Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector3Test.som
@@ -54,7 +54,7 @@ Vector3Test = TestCase (
       self assert: 1 equals: v first ].
 
     1 to: 10 do: [:i |
-      self assert: 1 equals: v first.
+      self assert: i equals: v first.
       v removeFirst ]
   )
 
@@ -148,7 +148,7 @@ Vector3Test = TestCase (
     self assert: 1 equals: (arr at: 1).
     self assert: 2 equals: (arr at: 2).
   )
-  
+
   testAsSet = (
     | v set |
     v := Vector new.
@@ -157,38 +157,38 @@ Vector3Test = TestCase (
     v append: 3.
     v append: 4.
     self assert: 4 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
-    
+
     v append: 1.
     v append: 1.
     v append: 1.
-    
+
     self assert: 4 + 3 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
   )
-  
+
   testIsEmpty = (
     | v |
     v := Vector new.
     self assert: v isEmpty.
-    
+
     v append: 1.
     self deny: v isEmpty.
-    
+
     v removeFirst.
     self assert: v isEmpty.
-    
+
     v append: #ee.
     self deny: v isEmpty.
-    
+
     v removeFirst.
-    self assert: v isEmpty.    
+    self assert: v isEmpty.
   )
-  
+
   testRemoveObj = (
     | v |
     v := Vector new.
@@ -200,31 +200,31 @@ Vector3Test = TestCase (
     v append: #f.
     v append: #g.
     v append: #h.
-    
+
     self assert: 8 equals: v size.
-    
+
     self deny: (v remove: #aa).
     self assert: (v remove: #e).
     self assert: 7 equals: v size.
   )
-  
+
   testAppendComma = (
     | v |
     v := Vector new.
     v, #a.
     v, #b.
-    
+
     self assert: 2 equals: v size.
     self assert: (v contains: #a).
     self assert: (v contains: #b).
   )
-  
+
   testDoIndexes = (
     | i v |
     v := Vector new.
     v doIndexes: [:j |
       self assert: false ].
-    
+
     v appendAll: #(1 2 3 4 5).
     i := 1.
     v doIndexes: [:j |
@@ -233,7 +233,7 @@ Vector3Test = TestCase (
     ].
     self assert: 6 equals: i.
   )
-  
+
   testDo = (
     | i v |
     v := Vector new.

--- a/Examples/Benchmarks/TestSuite/Vector4Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector4Test.som
@@ -54,7 +54,7 @@ Vector4Test = TestCase (
       self assert: 1 equals: v first ].
 
     1 to: 10 do: [:i |
-      self assert: 1 equals: v first.
+      self assert: i equals: v first.
       v removeFirst ]
   )
 
@@ -148,7 +148,7 @@ Vector4Test = TestCase (
     self assert: 1 equals: (arr at: 1).
     self assert: 2 equals: (arr at: 2).
   )
-  
+
   testAsSet = (
     | v set |
     v := Vector new.
@@ -157,38 +157,38 @@ Vector4Test = TestCase (
     v append: 3.
     v append: 4.
     self assert: 4 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
-    
+
     v append: 1.
     v append: 1.
     v append: 1.
-    
+
     self assert: 4 + 3 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
   )
-  
+
   testIsEmpty = (
     | v |
     v := Vector new.
     self assert: v isEmpty.
-    
+
     v append: 1.
     self deny: v isEmpty.
-    
+
     v removeFirst.
     self assert: v isEmpty.
-    
+
     v append: #ee.
     self deny: v isEmpty.
-    
+
     v removeFirst.
-    self assert: v isEmpty.    
+    self assert: v isEmpty.
   )
-  
+
   testRemoveObj = (
     | v |
     v := Vector new.
@@ -200,31 +200,31 @@ Vector4Test = TestCase (
     v append: #f.
     v append: #g.
     v append: #h.
-    
+
     self assert: 8 equals: v size.
-    
+
     self deny: (v remove: #aa).
     self assert: (v remove: #e).
     self assert: 7 equals: v size.
   )
-  
+
   testAppendComma = (
     | v |
     v := Vector new.
     v, #a.
     v, #b.
-    
+
     self assert: 2 equals: v size.
     self assert: (v contains: #a).
     self assert: (v contains: #b).
   )
-  
+
   testDoIndexes = (
     | i v |
     v := Vector new.
     v doIndexes: [:j |
       self assert: false ].
-    
+
     v appendAll: #(1 2 3 4 5).
     i := 1.
     v doIndexes: [:j |
@@ -233,7 +233,7 @@ Vector4Test = TestCase (
     ].
     self assert: 6 equals: i.
   )
-  
+
   testDo = (
     | i v |
     v := Vector new.

--- a/Examples/Benchmarks/TestSuite/Vector5Test.som
+++ b/Examples/Benchmarks/TestSuite/Vector5Test.som
@@ -54,7 +54,7 @@ Vector5Test = TestCase (
       self assert: 1 equals: v first ].
 
     1 to: 10 do: [:i |
-      self assert: 1 equals: v first.
+      self assert: i equals: v first.
       v removeFirst ]
   )
 
@@ -148,7 +148,7 @@ Vector5Test = TestCase (
     self assert: 1 equals: (arr at: 1).
     self assert: 2 equals: (arr at: 2).
   )
-  
+
   testAsSet = (
     | v set |
     v := Vector new.
@@ -157,38 +157,38 @@ Vector5Test = TestCase (
     v append: 3.
     v append: 4.
     self assert: 4 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
-    
+
     v append: 1.
     v append: 1.
     v append: 1.
-    
+
     self assert: 4 + 3 equals: v size.
-    
+
     set := v asSet.
     self assert: 4 equals: set size.
   )
-  
+
   testIsEmpty = (
     | v |
     v := Vector new.
     self assert: v isEmpty.
-    
+
     v append: 1.
     self deny: v isEmpty.
-    
+
     v removeFirst.
     self assert: v isEmpty.
-    
+
     v append: #ee.
     self deny: v isEmpty.
-    
+
     v removeFirst.
-    self assert: v isEmpty.    
+    self assert: v isEmpty.
   )
-  
+
   testRemoveObj = (
     | v |
     v := Vector new.
@@ -200,31 +200,31 @@ Vector5Test = TestCase (
     v append: #f.
     v append: #g.
     v append: #h.
-    
+
     self assert: 8 equals: v size.
-    
+
     self deny: (v remove: #aa).
     self assert: (v remove: #e).
     self assert: 7 equals: v size.
   )
-  
+
   testAppendComma = (
     | v |
     v := Vector new.
     v, #a.
     v, #b.
-    
+
     self assert: 2 equals: v size.
     self assert: (v contains: #a).
     self assert: (v contains: #b).
   )
-  
+
   testDoIndexes = (
     | i v |
     v := Vector new.
     v doIndexes: [:j |
       self assert: false ].
-    
+
     v appendAll: #(1 2 3 4 5).
     i := 1.
     v doIndexes: [:j |
@@ -233,7 +233,7 @@ Vector5Test = TestCase (
     ].
     self assert: 6 equals: i.
   )
-  
+
   testDo = (
     | i v |
     v := Vector new.

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -3,369 +3,270 @@
 default_experiment: all
 default_data_file: 'codespeed.data'
 
-reporting:
-    codespeed:
-        url: https://som-speed.stefan-marr.de/result/add/json/
-
 runs:
     max_invocation_time: 6000
+    min_iteration_time:  10
 
 benchmark_suites:
     macro-startup:
         gauge_adapter: RebenchLog
-        command: &MACRO_CMD "-cp Smalltalk:/home/smarr/.local/SOM/Examples/Benchmarks/Richards:/home/smarr/.local/SOM/Examples/Benchmarks/DeltaBlue:/home/smarr/.local/SOM/Examples/Benchmarks/NBody:/home/smarr/.local/SOM/Examples/Benchmarks/Json:/home/smarr/.local/SOM/Examples/Benchmarks/GraphSearch /home/smarr/.local/SOM/Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
+        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
         benchmarks:
             - Richards:
-                extra_args: "1 0 1"
-                codespeed_name: "Richards [>"
+                extra_args: "1 1"
             - DeltaBlue:
-                extra_args: "1 0 1000"
-                codespeed_name: "DeltaBlue [>"
+                extra_args: "1 1000"
             - Mandelbrot:
-                extra_args: "1 0 300"
-                codespeed_name: "Mandelbrot [>"
+                extra_args: "1 300"
             - NBody:
-                extra_args: "1 0 30000"
-                codespeed_name: "NBody [>"
+                extra_args: "1 30000"
             - Json:
-                extra_args: "1 0 80"
-                codespeed_name: "Json [>"
+                extra_args: "1 80"
             - GraphSearch:
-                extra_args: "1 0 30"
-                codespeed_name: "GraphSearch [>"
+                extra_args: "1 30"
             - PageRank:
-                extra_args: "1 0 1400"
-                codespeed_name: "PageRank [>"
+                extra_args: "1 1400"
 
     macro-steady:
         gauge_adapter: RebenchLog
         command: *MACRO_CMD
         benchmarks:
             - Richards:
-                extra_args: "130 0 60"
-                codespeed_name: "Richards >]"
+                extra_args: "130 60"
                 warmup: 30
             - DeltaBlue:
-                extra_args: "120 0 20000"
-                codespeed_name: "DeltaBlue >]"
+                extra_args: "120 20000"
                 warmup: 20
             - Mandelbrot:
-                extra_args: "110 0 1000"
-                codespeed_name: "Mandelbrot >]"
+                extra_args: "110 1000"
                 warmup: 10
             - NBody:
-                extra_args: "120 0 500000"
-                codespeed_name: "NBody >]"
+                extra_args: "120 500000"
                 warmup: 20
             - Json:
-                extra_args: "120 0 80"
-                codespeed_name: "Json >]"
+                extra_args: "120 80"
                 warmup: 20
             - GraphSearch:
-                extra_args: "250 0 30"
-                codespeed_name: "GraphSearch >]"
+                extra_args: "250 30"
                 warmup: 100
             - PageRank:
-                extra_args: "120 0 1400"
-                codespeed_name: "PageRank >]"
+                extra_args: "120 1400"
                 warmup: 20
 
     micro-startup-100:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:/home/smarr/.local/SOM/Examples/Benchmarks/LanguageFeatures /home/smarr/.local/SOM/Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
         benchmarks:
             - Fibonacci:
-                extra_args: "1 0 100"
-                codespeed_name: "Fibonacci 100x [>"
+                extra_args: "1 100"
             - Dispatch:
-                extra_args: "1 0 1000"
-                codespeed_name: "Dispatch 100x [>"
+                extra_args: "1 1000"
             - Bounce:
-                extra_args: "1 0 100"
-                codespeed_name: "Bounce 100x [>"
+                extra_args: "1 100"
             - Loop:
-                extra_args: "1 0 500"
-                codespeed_name: "Loop 100x [>"
+                extra_args: "1 500"
             - Permute:
-                extra_args: "1 0 50"
-                codespeed_name: "Permute 100x [>"
+                extra_args: "1 50"
             - Queens:
-                extra_args: "1 0 50"
-                codespeed_name: "Queens 100x [>"
+                extra_args: "1 50"
             - List:
-                extra_args: "1 0 50"
-                codespeed_name: "List 100x [>"
+                extra_args: "1 50"
             - Recurse:
-                extra_args: "1 0 100"
-                codespeed_name: "Recurse 100x [>"
+                extra_args: "1 100"
             - Storage:
-                extra_args: "1 0 20"
-                codespeed_name: "Storage 100x [>"
+                extra_args: "1 20"
             - Sieve:
-                extra_args: "1 0 100"
-                codespeed_name: "Sieve 100x [>"
+                extra_args: "1 100"
             - BubbleSort:
-                extra_args: "1 0 100"
-                codespeed_name: "BubbleSort 100x [>"
+                extra_args: "1 100"
             - QuickSort:
-                extra_args: "1 0 20"
-                codespeed_name: "QuickSort 100x [>"
+                extra_args: "1 20"
             - Sum:
-                extra_args: "1 0 500"
-                codespeed_name: "Sum 100x [>"
+                extra_args: "1 500"
             - Towers:
-                extra_args: "1 0 20"
-                codespeed_name: "Towers 100x [>"
+                extra_args: "1 20"
             - TreeSort:
-                extra_args: "1 0 10"
-                codespeed_name: "TreeSort 100x [>"
+                extra_args: "1 10"
             - IntegerLoop:
-                extra_args: "1 0 400"
-                codespeed_name: "IntegerLoop 100x [>"
+                extra_args: "1 400"
             - FieldLoop:
-                extra_args: "1 0 50"
-                codespeed_name: "FieldLoop 100x [>"
+                extra_args: "1 50"
             - WhileLoop:
-                extra_args: "1 0 1000"
-                codespeed_name: "WhileLoop 100x [>"
+                extra_args: "1 1000"
 
     micro-startup:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:/home/smarr/.local/SOM/Examples/Benchmarks/LanguageFeatures /home/smarr/.local/SOM/Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
         benchmarks:
             - Fibonacci:
-                extra_args: "1 0 3"
-                codespeed_name: "Fibonacci [>"
+                extra_args: "1 3"
             - Dispatch:
-                extra_args: "1 0 20"
-                codespeed_name: "Dispatch [>"
+                extra_args: "1 20"
             - Bounce:
-                extra_args: "1 0 2"
-                codespeed_name: "Bounce [>"
+                extra_args: "1 2"
             - Loop:
-                extra_args: "1 0 10"
-                codespeed_name: "Loop [>"
+                extra_args: "1 10"
             - Permute:
-                extra_args: "1 0 3"
-                codespeed_name: "Permute [>"
+                extra_args: "1 3"
             - Queens:
-                extra_args: "1 0 2"
-                codespeed_name: "Queens [>"
+                extra_args: "1 2"
             - List:
-                extra_args: "1 0 2"
-                codespeed_name: "List [>"
+                extra_args: "1 2"
             - Recurse:
-                extra_args: "1 0 3"
-                codespeed_name: "Recurse [>"
+                extra_args: "1 3"
             - Storage:
-                extra_args: "1 0 2"
-                codespeed_name: "Storage [>"
+                extra_args: "1 2"
             - Sieve:
-                extra_args: "1 0 5"
-                codespeed_name: "Sieve [>"
+                extra_args: "1 5"
             - BubbleSort:
-                extra_args: "1 0 3"
-                codespeed_name: "BubbleSort [>"
+                extra_args: "1 3"
             - QuickSort:
-                extra_args: "1 0 3"
-                codespeed_name: "QuickSort [>"
+                extra_args: "1 3"
             - Sum:
-                extra_args: "1 0 10"
-                codespeed_name: "Sum [>"
+                extra_args: "1 10"
             - Towers:
-                extra_args: "1 0 2"
-                codespeed_name: "Towers [>"
+                extra_args: "1 2"
             - TreeSort:
-                extra_args: "1 0 1"
-                codespeed_name: "TreeSort [>"
+                extra_args: "1 1"
             - IntegerLoop:
-                extra_args: "1 0 8"
-                codespeed_name: "IntegerLoop [>"
+                extra_args: "1 8"
             - FieldLoop:
-                extra_args: "1 0 3"
-                codespeed_name: "FieldLoop [>"
+                extra_args: "1 3"
             - WhileLoop:
-                extra_args: "1 0 30"
-                codespeed_name: "WhileLoop [>"
+                extra_args: "1 30"
 
     micro-steady-100:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:/home/smarr/.local/SOM/Examples/Benchmarks/LanguageFeatures /home/smarr/.local/SOM/Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
         benchmarks:
             - Fannkuch:
-                extra_args: "55 0 9"
-                codespeed_name: "Fannkuch 100x >]"
+                extra_args: "55 9"
                 warmup: 5
             - Fibonacci:
-                extra_args: "60 0 1000"
-                codespeed_name: "Fibonacci 100x >]"
+                extra_args: "60 1000"
                 warmup: 10
             - Dispatch:
-                extra_args: "55 0 10000"
-                codespeed_name: "Dispatch 100x >]"
+                extra_args: "55 10000"
                 warmup: 5
             - Bounce:
-                extra_args: "60 0 4000"
-                codespeed_name: "Bounce 100x >]"
+                extra_args: "60 4000"
                 warmup: 10
             - Loop:
-                extra_args: "55 0 10000"
-                codespeed_name: "Loop 100x >]"
+                extra_args: "55 10000"
                 warmup: 5
             - Permute:
-                extra_args: "55 0 1500"
-                codespeed_name: "Permute 100x >]"
+                extra_args: "55 1500"
                 warmup: 5
             - Queens:
-                extra_args: "55 0 1000"
-                codespeed_name: "Queens 100x >]"
+                extra_args: "55 1000"
                 warmup: 5
             - List:
-                extra_args: "65 0 1000"
-                codespeed_name: "List 100x >]"
+                extra_args: "65 1000"
                 warmup: 15
             - Recurse:
-                extra_args: "65 0 2000"
-                codespeed_name: "Recurse 100x >]"
+                extra_args: "65 2000"
                 warmup: 15
             - Storage:
-                extra_args: "60 0 1000"
-                codespeed_name: "Storage 100x >]"
+                extra_args: "60 1000"
                 warmup: 10
             - Sieve:
-                extra_args: "60 0 2500"
-                codespeed_name: "Sieve 100x >]"
+                extra_args: "60 2500"
                 warmup: 10
             - BubbleSort:
-                extra_args: "60 0 3000"
-                codespeed_name: "BubbleSort 100x >]"
+                extra_args: "60 3000"
                 warmup: 10
             - QuickSort:
-                extra_args: "60 0 2000"
-                codespeed_name: "QuickSort 100x >]"
+                extra_args: "60 2000"
                 warmup: 10
             - Sum:
-                extra_args: "55 0 10000"
-                codespeed_name: "Sum 100x >]"
+                extra_args: "55 10000"
                 warmup: 5
             - Towers:
-                extra_args: "55 0 1000"
-                codespeed_name: "Towers 100x >]"
+                extra_args: "55 1000"
                 warmup: 5
             - TreeSort:
-                extra_args: "60 0 1000"
-                codespeed_name: "TreeSort 100x >]"
+                extra_args: "60 1000"
                 warmup: 10
             - IntegerLoop:
-                extra_args: "55 0 8000"
-                codespeed_name: "IntegerLoop 100x >]"
+                extra_args: "55 8000"
                 warmup: 5
             - FieldLoop:
-                extra_args: "55 0 900"
-                codespeed_name: "FieldLoop 100x >]"
+                extra_args: "55 900"
                 warmup: 5
             - WhileLoop:
-                extra_args: "55 0 9000"
-                codespeed_name: "WhileLoop 100x >]"
+                extra_args: "55 9000"
                 warmup: 5
     micro-steady:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:/home/smarr/.local/SOM/Examples/Benchmarks/LanguageFeatures /home/smarr/.local/SOM/Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s "
         benchmarks:
             - Fannkuch:
-                extra_args: "14 0 6"
-                codespeed_name: "Fannkuch >]"
+                extra_args: "14 6"
                 warmup: 4
             - Fibonacci:
-                extra_args: "15 0 3"
-                codespeed_name: "Fibonacci >]"
+                extra_args: "15 3"
                 warmup: 5
             - Dispatch:
-                extra_args: "12 0 20"
-                codespeed_name: "Dispatch >]"
+                extra_args: "12 20"
                 warmup: 2
             - Bounce:
-                extra_args: "22 0 2"
-                codespeed_name: "Bounce >]"
+                extra_args: "22 2"
                 warmup: 12
             - Loop:
-                extra_args: "14 0 10"
-                codespeed_name: "Loop >]"
+                extra_args: "14 10"
                 warmup: 4
             - Permute:
-                extra_args: "16 0 3"
-                codespeed_name: "Permute >]"
+                extra_args: "16 3"
                 warmup: 6
             - Queens:
-                extra_args: "13 0 2"
-                codespeed_name: "Queens >]"
+                extra_args: "13 2"
                 warmup: 3
             - List:
-                extra_args: "16 0 2"
-                codespeed_name: "List >]"
+                extra_args: "16 2"
                 warmup: 6
             - Recurse:
-                extra_args: "14 0 3"
-                codespeed_name: "Recurse >]"
+                extra_args: "14 3"
                 warmup: 4
             - Storage:
-                extra_args: "17 0 2"
-                codespeed_name: "Storage >]"
+                extra_args: "17 2"
                 warmup: 7
             - Sieve:
-                extra_args: "18 0 5"
-                codespeed_name: "Sieve >]"
+                extra_args: "18 5"
                 warmup: 8
             - BubbleSort:
-                extra_args: "16 0 3"
-                codespeed_name: "BubbleSort >]"
+                extra_args: "16 3"
                 warmup: 6
             - QuickSort:
-                extra_args: "15 0 3"
-                codespeed_name: "QuickSort >]"
+                extra_args: "15 3"
                 warmup: 5
             - Sum:
-                extra_args: "20 0 10"
-                codespeed_name: "Sum >]"
+                extra_args: "20 10"
                 warmup: 10
             - Towers:
-                extra_args: "20 0 2"
-                codespeed_name: "Towers >]"
+                extra_args: "20 2"
                 warmup: 10
             - TreeSort:
-                extra_args: "15 0 1"
-                codespeed_name: "TreeSort >]"
+                extra_args: "15 1"
                 warmup: 5
             - IntegerLoop:
-                extra_args: "14 0 8"
-                codespeed_name: "IntegerLoop >]"
+                extra_args: "14 8"
                 warmup: 4
             - FieldLoop:
-                extra_args: "12 0 3"
-                codespeed_name: "FieldLoop >]"
+                extra_args: "12 3"
                 warmup: 2
             - WhileLoop:
-                extra_args: "13 0 30"
-                codespeed_name: "WhileLoop >]"
+                extra_args: "13 30"
                 warmup: 3
 
 executors:
     SOM:
-        path: .
+        path: ..
         executable: som.sh
 
     TruffleSOM-interpreter:
         path: . 
         executable: som.sh
     TruffleSOM-graal:
-        path: . 
-        executable: som
-        args: "-E"
-
-    TruffleSOM-interpreter-exp:
-        path: . 
-        executable: som.sh
-    TruffleSOM-graal-exp:
         path: . 
         executable: som
         args: "-E"
@@ -379,30 +280,18 @@ executors:
     PySOM:
         path: .
         executable: som.sh
-    RPySOM-interpreter:
-        path: .
-        executable: RPySOM-no-jit
-    RPySOM-jit:
-        path: .
-        executable: RPySOM-jit
-    RTruffleSOM-interpreter:
-        path: .
-        executable: RTruffleSOM-no-jit
-    RTruffleSOM-jit:
-        path: .
-        executable: RTruffleSOM-jit
         
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:
     SOM:
         description: All benchmarks on SOM (Java, bytecode-based)
         suites:
-            - micro-startup-100
-            - micro-steady-100
+            # - micro-startup-100
+            # - micro-steady-100
             - micro-startup
-            - micro-steady
+            # - micro-steady
             - macro-startup
-            - macro-steady
+            # - macro-steady
         executions:
             - SOM
     TruffleSOM:
@@ -415,16 +304,6 @@ experiments:
         executions:
             #- TruffleSOM-interpreter
             - TruffleSOM-graal
-    TruffleSOM-exp:
-        description: All benchmarks on TruffleSOM (Java, AST Interpreter)
-        suites:
-            - micro-startup-100
-            - micro-steady-100
-            - macro-startup
-            - macro-steady
-        executions:
-            #- TruffleSOM-interpreter
-            - TruffleSOM-graal-exp
 
     CSOM:
         description: All benchmarks on CSOM
@@ -449,47 +328,3 @@ experiments:
             - macro-startup
         executions:
             - PySOM
-    RPySOM:
-        description: All benchmarks on RPySOM
-        suites:
-            #- micro-startup
-            #- micro-steady
-            - micro-startup-100
-            - micro-steady-100
-            - macro-startup
-            - macro-steady
-        executions:
-            #- RPySOM-interpreter
-            - RPySOM-jit
-    RTruffleSOM:
-        description: All benchmarks on RTruffleSOM
-        suites:
-            #- micro-startup
-            #- micro-steady
-            - micro-startup-100
-            - micro-steady-100
-            - macro-startup
-            - macro-steady
-        executions:
-            #- RTruffleSOM-interpreter
-            - RTruffleSOM-jit
-    RTruffleSOM-OMOP:
-        description: All benchmarks on RTruffleSOM
-        suites:
-            #- micro-startup
-            #- micro-steady
-            - micro-startup-100
-            - micro-steady-100
-            - macro-startup
-            - macro-steady
-        executions:
-            #- RTruffleSOM-interpreter
-            - RTruffleSOM-jit
-    TruffleSOM-OMOP:
-        suites:
-            - micro-startup-100
-            - micro-steady-100
-            - macro-startup
-            - macro-steady
-        executions:
-            - TruffleSOM-graal

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -258,6 +258,28 @@ benchmark_suites:
                 extra_args: "13 30"
                 warmup: 3
 
+    interpreter:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
+        benchmarks:
+            - ArgRead
+            - ArrayReadConst
+            - ArrayWriteConstConst
+            - BlockSend0ConstReturn
+            - Const
+            - FieldConstWrite
+            - FieldRead
+            - FieldReadIncWrite
+            - FieldReadWrite
+            - GlobalRead
+            - LocalConstWrite
+            - LocalRead
+            - LocalReadIncWrite
+            - LocalReadWrite
+            - SelfSend0
+            - SelfSend0BlockConstNonLocalReturn
+
 executors:
     SOM:
         path: ..
@@ -292,6 +314,7 @@ experiments:
             # - micro-steady
             - macro-startup
             # - macro-steady
+            - interpreter
         executions:
             - SOM
     TruffleSOM:


### PR DESCRIPTION
First this PR reorganizes the benchmarks introduced in #119 and renames them.

Benchmarks now try to consistently use a name that roughly describes the expression that is evaluated in the loop body.

Each benchmark follows the same structure that tries to focus the execution of a particular expression. It is executed 30 times inside a loop, which hopefully should make sure that these expressions dominate the overall execution time.

The current micro, or perhaps rather nanobenchmark set is:

| Benchmark                         | Expression | Description |
| --------------------------------- | ---------- | ------------ |
| ArgRead                           | `arg`      | read a method argument |
| ArrayReadConst                    | `arr at: 1` | read a method argument |
| ArrayWriteConstConst              | `arr at: 1 put: 2` | write a constant to an array at contant index |
| BlockSend0ConstReturn             | `[ 0 ] value` | activate block that evaluates to constant |
| Const                             | `42` | read a literal |
| FieldConstWrite                   | `field := 1` | write a constant to field |
| FieldRead                         | `field` | read field |
| FieldReadIncWrite                 | `field := field + 1` | read, add 1, and write to a field |
| FieldReadWrite                    | `field := field` | read field and write to field |
| GlobalRead                        | `GlobalRead` | read global |
| LocalConstWrite                   | `local := 1` | write constant to local |
| LocalRead                         | `local` | read local variable |
| LocalReadIncWrite                 | `local := local + 1` | read, add 1, and write to a local |
| LocalReadWrite                    | `local := local` | read and write local |
| SelfSend0                         | `self trivial` | self send message without argument to `trivial = ( ^ 1 )` |
| SelfSend0BlockConstNonLocalReturn | `self trivial` | self send message, which returns nonlocally from an embedded block: `trivial = ( [ ^ 42 ] value )` |


### Core-Lib Updates

| Status 	| SOM        	| PR                                           	|
|:------:	|------------	|----------------------------------------------	|
| :white_check_mark: | SOM (java) 	| https://github.com/SOM-st/som-java/pull/36   	|
| :white_check_mark: | TruffleSOM 	| https://github.com/SOM-st/TruffleSOM/pull/205	|
| :white_check_mark: | PySOM      	| https://github.com/SOM-st/PySOM/pull/61 |
| :white_check_mark: | JsSOM      	| https://github.com/SOM-st/JsSOM/pull/17 |
| :white_check_mark: | SOM-RS     	| https://github.com/Hirevo/som-rs/pull/46 |
