### PR TITLE
Add #ifNotNil:ifNil: to Nil and Object

### DIFF
--- a/Examples/Benchmarks/TestSuite/Reflection2Test.som
+++ b/Examples/Benchmarks/TestSuite/Reflection2Test.som
@@ -78,7 +78,7 @@ Reflection2Test = TestCase (
   testSelectors = (
     | sels |
     sels := Object selectors.
-    self assert: 32 equals: sels length.
+    self assert: 33 equals: sels length.
     
     sels contains: #=.
     self assert: (Object hasMethod: #=).

--- a/Examples/Benchmarks/TestSuite/Reflection3Test.som
+++ b/Examples/Benchmarks/TestSuite/Reflection3Test.som
@@ -78,7 +78,7 @@ Reflection3Test = TestCase (
   testSelectors = (
     | sels |
     sels := Object selectors.
-    self assert: 32 equals: sels length.
+    self assert: 33 equals: sels length.
     
     sels contains: #=.
     self assert: (Object hasMethod: #=).

--- a/Examples/Benchmarks/TestSuite/Reflection4Test.som
+++ b/Examples/Benchmarks/TestSuite/Reflection4Test.som
@@ -78,7 +78,7 @@ Reflection4Test = TestCase (
   testSelectors = (
     | sels |
     sels := Object selectors.
-    self assert: 32 equals: sels length.
+    self assert: 33 equals: sels length.
     
     sels contains: #=.
     self assert: (Object hasMethod: #=).

--- a/Examples/Benchmarks/TestSuite/Reflection5Test.som
+++ b/Examples/Benchmarks/TestSuite/Reflection5Test.som
@@ -78,7 +78,7 @@ Reflection5Test = TestCase (
   testSelectors = (
     | sels |
     sels := Object selectors.
-    self assert: 32 equals: sels length.
+    self assert: 33 equals: sels length.
     
     sels contains: #=.
     self assert: (Object hasMethod: #=).

--- a/Examples/Benchmarks/TestSuite/ReflectionTest.som
+++ b/Examples/Benchmarks/TestSuite/ReflectionTest.som
@@ -78,7 +78,7 @@ ReflectionTest = TestCase (
   testSelectors = (
     | sels |
     sels := Object selectors.
-    self assert: 32 equals: sels length.
+    self assert: 33 equals: sels length.
     
     sels contains: #=.
     self assert: (Object hasMethod: #=).

--- a/Smalltalk/Nil.som
+++ b/Smalltalk/Nil.som
@@ -27,7 +27,7 @@ Nil = (
 
     "Converting"
     asString = ( ^'nil' )
-    
+
     "Comparing"
     isNil    = ( ^true )
     notNil   = ( ^false )
@@ -36,5 +36,5 @@ Nil = (
     ifNil: aBlock = (^aBlock value)
     ifNotNil: aBlock = (^self)
     ifNil: goBlock ifNotNil: noGoBlock = (^goBlock value)
-
+    ifNotNil: noGoBlock ifNil: goBlock = (^goBlock value)
 )

--- a/Smalltalk/Object.som
+++ b/Smalltalk/Object.som
@@ -51,7 +51,8 @@ Object = nil (
     ifNil: aBlock = (^self)
     ifNotNil: aBlock = (^aBlock value)
     ifNil: noGoBlock ifNotNil: goBlock = (^goBlock value)
-    
+    ifNotNil: goBlock ifNil: noGoBlock = (^goBlock value)
+
     "Printing"
     print     = ( self asString print )
     println   = ( self print. system printNewline )

--- a/Smalltalk/Object.som
+++ b/Smalltalk/Object.som
@@ -26,7 +26,7 @@ THE SOFTWARE.
 Object = nil (
     class      = primitive
     objectSize = primitive  "size in bytes"
-    
+
     "Comparing"
 
     " If you override =, you MUST override hashcode as well.  The rule
@@ -38,15 +38,15 @@ Object = nil (
     ~= other    = (^ (self == other) not )
     isNil       = ( ^false )
     notNil      = ( ^true )
-    
+
     "Converting"
     asString  = ( ^'instance of ' + (self class) )
     , element = ( ^(Vector new append: self) append: element )
     hashcode  = primitive
-    
+
     "Evaluating"
     value     = ( ^self )
-    
+
     "Convenience"
     ifNil: aBlock = (^self)
     ifNotNil: aBlock = (^aBlock value)
@@ -60,27 +60,27 @@ Object = nil (
     "Debugging"
     inspect   = primitive
     halt      = primitive
-    
+
     "Error handling"
     error: string = ( '' println. ('ERROR: ' + string) println. system exit: 1 )
-    
+
     "Abstract method support"
     subclassResponsibility = (
         self error: 'This method is abstract and should be overridden'
     )
-    
+
     "Error recovering"
     doesNotUnderstand: selector arguments: arguments = (
         self error:
             ('Method ' + selector + ' not found in class ' + self class name)
     )
-    
+
     escapedBlock: block = (
         self error: 'Block has escaped and cannot be executed'
     )
-    
+
     unknownGlobal: name = ( ^system resolve: name )
-    
+
     "Reflection"
     respondsTo: aSymbol = (
         (self class hasMethod: aSymbol)
@@ -93,13 +93,13 @@ Object = nil (
                         ifFalse: [ cls := cls superclass ] ].
                 ^ false ]
     )
-    
+
     perform: aSymbol = primitive
     perform: aSymbol withArguments: args = primitive
-    
+
     perform: aSymbol inSuperclass: cls = primitive
     perform: aSymbol withArguments: args inSuperclass: cls = primitive
-    
+
     instVarAt: idx          = primitive
     instVarAt: idx put: obj = primitive
     instVarNamed: sym       = primitive

--- a/TestSuite/BooleanTest.som
+++ b/TestSuite/BooleanTest.som
@@ -172,4 +172,14 @@ BooleanTest = TestCase (
       self assert: (nil ifNotNil: [ #notExec ]) is: nil.
       self assert: (nil ifNotNil: [ #notExec ]) is: nil.
     )
+
+    testIfNilIfNotNil = (
+      self assert: (nil ifNil: [ #exec ] ifNotNil: [ #notExec ]) is: #exec.
+      self assert: (self ifNil: [ #notExec ] ifNotNil: [ #exec ]) is: #exec.
+    )
+
+    testIfNotNilIfNil = (
+      self assert: (nil ifNotNil: [ #exec ] ifNil: [ #notExec ]) is: #notExec.
+      self assert: (self ifNotNil: [ #exec ] ifNil: [ #notExec ]) is: #exec.
+    )
 )

--- a/TestSuite/ReflectionTest.som
+++ b/TestSuite/ReflectionTest.som
@@ -78,8 +78,8 @@ ReflectionTest = TestCase (
   testSelectors = (
     | sels |
     sels := Object selectors.
-    self assert: 32 equals: sels length.
-    
+    self assert: 33 equals: sels length.
+
     sels contains: #=.
     self assert: (Object hasMethod: #=).
     

--- a/TestSuite/ReflectionTest.som
+++ b/TestSuite/ReflectionTest.som
@@ -31,7 +31,7 @@ ReflectionTest = TestCase (
     self assert: (23 respondsTo: #isNil).
     self assert: (23 respondsTo: #+).
   )
-  
+
   testMethods = (
     "First method in Object should be #class."
     self assert: #class equals: (Object methods at: 1) signature.
@@ -42,39 +42,39 @@ ReflectionTest = TestCase (
     | o |
     self assert: Integer equals: (23 perform: #class).
     self assert: (23 perform: #between:and: withArguments: (Array with: 22 with: 24)).
-    
+
     o := SuperTest new.
     self assert: #super equals: (o perform: #something inSuperclass: SuperTestSuperClass).
-    
+
     "Trying to see whether the stack in bytecode-based SOMs works properly"
     self assert: #a equals: ((23 perform: #class) = Integer ifTrue: [#a] ifFalse: [#b]).
 
     self assert: 28 equals: 5 + (23 perform: #value).
   )
-  
+
   testInstVarAtAndPut = (
     | tmp |
     "Testing #at: and #at:put:"
     tmp := Pair withKey: 3 andValue: 42.
-    
+
     self assert: tmp key equals: (tmp instVarAt: 1).
-    
+
     tmp instVarAt: 1 put: #foo.
     self assert: #foo    equals: tmp key.
   )
-  
+
   testName = (
     self assert: #Object equals: Object name.
     self assert: #'Object class' equals: Object class name.
     self assert: #Integer equals: 1 class name.
   )
-  
+
   testAsString = (
     self assert: 'Object' equals: Object asString.
     self assert: 'Object class' equals: Object class asString.
     self assert: 'Integer' equals: 1 class asString.
   )
-  
+
   testSelectors = (
     | sels |
     sels := Object selectors.
@@ -82,10 +82,10 @@ ReflectionTest = TestCase (
 
     sels contains: #=.
     self assert: (Object hasMethod: #=).
-    
+
     sels contains: #value.
     self assert: (Object hasMethod: #value).
-    
+
     sels contains: #notNil.
     self assert: (Object hasMethod: #notNil).
   )


### PR DESCRIPTION
This PR adds the missing selector for nil checks, with the first branch being the non-nil case. This is mostly for symmetry and convenience, since we already had the `#ifNil:ifNotNil:` case.

This change is relied on in the AreWeFastYet benchmarks with https://github.com/smarr/are-we-fast-yet/pull/99.


### Core-Lib Updates

| Status 	| SOM        	| PR                                           	|
|:------:	|------------	|----------------------------------------------	|
|  | SOM (java) 	| https://github.com/SOM-st/som-java/pull/   	|
|  | SOM++       	| https://github.com/SOM-st/som-java/pull/   	|
|  | TruffleSOM 	| https://github.com/SOM-st/TruffleSOM/pull/	|
|  | PySOM      	| https://github.com/SOM-st/PySOM/pull/ |
|  | JsSOM      	| https://github.com/SOM-st/JsSOM/pull/ |
|  | SOM-RS     	| https://github.com/Hirevo/som-rs/pull/ |
