### PR TITLE
Added benchmark for #ifNil:, #ifNotNil:, #ifNil:ifNotNil:, and #ifNotNil:ifNil:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test_soms:
-    runs-on: ubuntu-20.04 # ubuntu-latest
+    runs-on: ubuntu-24.04 # ubuntu-latest
     continue-on-error: ${{ matrix.not-up-to-date }}
     strategy:
       fail-fast: false # we want all jobs to run, because they may fail independently

--- a/Examples/Benchmarks/LanguageFeatures/IfNil.som
+++ b/Examples/Benchmarks/LanguageFeatures/IfNil.som
@@ -1,0 +1,47 @@
+"
+Copyright (c) 2025 see AUTHORS file
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"
+
+IfNil = Benchmark (
+
+    benchmark = (
+        | cnt |
+        cnt := 0.
+        1 to: 20000 do: [:i |
+            self ifNil: [ self error: 'wrong branch 1' ].
+            nil  ifNil: [ cnt := cnt + 1 ].
+
+            self ifNotNil: [ cnt := cnt + 1 ].
+            nil  ifNotNil: [ self error: 'wrong branch 2' ].
+
+            self ifNil: [ self error: 'wrong branch 3' ] ifNotNil: [ cnt := cnt + 1 ].
+            nil  ifNil: [ cnt := cnt + 1 ] ifNotNil: [ self error: 'wrong branch 4' ].
+
+            self ifNotNil: [ cnt := cnt + 1 ] ifNil: [ self error: 'wrong branch 5' ].
+            nil  ifNotNil: [ self error: 'wrong branch 6' ] ifNil: [ cnt := cnt + 1 ].
+        ].
+        ^ cnt
+    )
+
+    verifyResult: result = (
+      ^ 120000 = result
+    )
+)

--- a/TestSuite/BooleanTest.som
+++ b/TestSuite/BooleanTest.som
@@ -161,21 +161,21 @@ BooleanTest = TestCase (
       self assert: (nil ifNil: [ true ]).
       self deny:   (nil ifNil: [ false ]).
 
-      self assert: (self ifNil: [ #notExec ]) is: self.
-      self assert: (self ifNil: [ #notExec ]) is: self.
+      self assert: #rcvr is: (#rcvr ifNil: [ #notExec ]).
+      self assert: #rcvr is: (#rcvr ifNil: [ #notExec ]).
     )
 
     testIfNotNil = (
       self assert: (self ifNotNil: [ true ]).
       self deny:   (self ifNotNil: [ false ]).
 
-      self assert: (nil ifNotNil: [ #notExec ]) is: nil.
-      self assert: (nil ifNotNil: [ #notExec ]) is: nil.
+      self assert: nil is: (nil ifNotNil: [ #notExec ]).
+      self assert: nil is: (nil ifNotNil: [ #notExec ]).
     )
 
     testIfNilIfNotNil = (
-      self assert: (nil ifNil: [ #exec ] ifNotNil: [ #notExec ]) is: #exec.
-      self assert: (self ifNil: [ #notExec ] ifNotNil: [ #exec ]) is: #exec.
+      self assert: #exec is: (nil ifNil: [ #exec ] ifNotNil: [ #notExec ]).
+      self assert: #exec is: (self ifNil: [ #notExec ] ifNotNil: [ #exec ]).
     )
 
     testIfNotNilIfNil = (


### PR DESCRIPTION
This is a microbenchmark for the methods introduced in https://github.com/SOM-st/SOM/pull/123.
The main purpose is to track whether these methods are inlined in interpreters.

Also:
 - improve tests
 - update GitHub Actions setup