### PR TITLE
Enable Testing on SOM++ and make Test benchmark work on all SOMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,7 @@ jobs:
           ${{ matrix.som }} -cp ../Smalltalk:../Examples/Benchmarks/TestSuite ../Examples/Benchmarks/BenchmarkHarness.som Test100 1 1
 
       - name: Test All Benchmark
-        # ignore VMs that give slighly different results for tests
-        if: ${{ matrix.repo != 'som-rs.git' && matrix.som != 'spec' && matrix.repo != 'JsSOM.git' && matrix.repo != 'PySOM.git' }}
+        if: ${{ matrix.som != 'spec' }}
         run: |
           cd som-vm
           ${{ matrix.som }} -cp ../Smalltalk:../Examples/Benchmarks/TestSuite:../Examples/Benchmarks/Richards:../Examples/Benchmarks/DeltaBlue:../Examples/Benchmarks/NBody:../Examples/Benchmarks/Json:../Examples/Benchmarks/GraphSearch:../Examples/Benchmarks/LanguageFeatures ../Examples/Benchmarks/BenchmarkHarness.som All 1 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false # we want all jobs to run, because they may fail independently
       matrix:
         include:
-          # - name: SOM++
-          #   repo: SOMpp.git
-          #   apt: libcppunit-dev
-          #   build: "cmake . && make SOM++"
-          #   som: "./som.sh"
-          #   not-up-to-date: true
+          - name: SOM++
+            repo: SOMpp.git
+            apt: libcppunit-dev
+            build: "cmake . && make SOM++"
+            som: "./SOM++"
+            not-up-to-date: false
 
           # - name: CSOM
           #   repo: CSOM.git
@@ -30,7 +30,7 @@ jobs:
             repo: JsSOM.git
             build: ""
             som: "./som.sh"
-            not-up-to-date: true
+            not-up-to-date: false
 
           - name: PySOM
             repo: PySOM.git

--- a/Examples/Benchmarks/TestSuite/ClassStructure2Test.som
+++ b/Examples/Benchmarks/TestSuite/ClassStructure2Test.som
@@ -25,14 +25,7 @@ ClassStructure2Test = TestCase (
     "This is a little fragile.
      Index needs to be adapted with changing Class definition."
     m := Object methods at: 1.
-    "self expect: #class equals: m signature."
-
-    self optional: #invokableTypes assert: Primitive equals: m class. "Class>>#name should be a primitive."
-
     m := Object methods at: 7.
-    "self expect: #asString equals: m signature."
-
-    self optional: #invokableTypes assert: Method equals: m class. "Class>>#asString should be a normal method."
   )
 
   testAccessToInstanceFields = (

--- a/Examples/Benchmarks/TestSuite/ClassStructure3Test.som
+++ b/Examples/Benchmarks/TestSuite/ClassStructure3Test.som
@@ -25,14 +25,7 @@ ClassStructure3Test = TestCase (
     "This is a little fragile.
      Index needs to be adapted with changing Class definition."
     m := Object methods at: 1.
-    "self expect: #class equals: m signature."
-
-    self optional: #invokableTypes assert: Primitive equals: m class. "Class>>#name should be a primitive."
-
     m := Object methods at: 7.
-    "self expect: #asString equals: m signature."
-
-    self optional: #invokableTypes assert: Method equals: m class. "Class>>#asString should be a normal method."
   )
 
   testAccessToInstanceFields = (

--- a/Examples/Benchmarks/TestSuite/ClassStructure4Test.som
+++ b/Examples/Benchmarks/TestSuite/ClassStructure4Test.som
@@ -25,14 +25,7 @@ ClassStructure4Test = TestCase (
     "This is a little fragile.
      Index needs to be adapted with changing Class definition."
     m := Object methods at: 1.
-    "self expect: #class equals: m signature."
-
-    self optional: #invokableTypes assert: Primitive equals: m class. "Class>>#name should be a primitive."
-
     m := Object methods at: 7.
-    "self expect: #asString equals: m signature."
-
-    self optional: #invokableTypes assert: Method equals: m class. "Class>>#asString should be a normal method."
   )
 
   testAccessToInstanceFields = (

--- a/Examples/Benchmarks/TestSuite/ClassStructure5Test.som
+++ b/Examples/Benchmarks/TestSuite/ClassStructure5Test.som
@@ -25,14 +25,7 @@ ClassStructure5Test = TestCase (
     "This is a little fragile.
      Index needs to be adapted with changing Class definition."
     m := Object methods at: 1.
-    "self expect: #class equals: m signature."
-
-    self optional: #invokableTypes assert: Primitive equals: m class. "Class>>#name should be a primitive."
-
     m := Object methods at: 7.
-    "self expect: #asString equals: m signature."
-
-    self optional: #invokableTypes assert: Method equals: m class. "Class>>#asString should be a normal method."
   )
 
   testAccessToInstanceFields = (

--- a/Examples/Benchmarks/TestSuite/ClassStructureTest.som
+++ b/Examples/Benchmarks/TestSuite/ClassStructureTest.som
@@ -25,14 +25,7 @@ ClassStructureTest = TestCase (
     "This is a little fragile.
      Index needs to be adapted with changing Class definition."
     m := Object methods at: 1.
-    "self expect: #class equals: m signature."
-
-    self optional: #invokableTypes assert: Primitive equals: m class. "Class>>#name should be a primitive."
-
     m := Object methods at: 7.
-    "self expect: #asString equals: m signature."
-
-    self optional: #invokableTypes assert: Method equals: m class. "Class>>#asString should be a normal method."
   )
 
   testAccessToInstanceFields = (

--- a/Examples/Benchmarks/TestSuite/Integer2Test.som
+++ b/Examples/Benchmarks/TestSuite/Integer2Test.som
@@ -38,13 +38,8 @@ Integer2Test = TestCase (
     "Sometimes it can be hard to implement efficiently, but it SHOULD really
      be true for all values of integers."
     a := 1 << 30.  b := 1 << 30.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 32.  b := 1 << 32.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 60.  b := 1 << 60.
-    self optional: #integerIdentity assert: a is: b.
   )
 
   testClassAndValueRanges = (
@@ -74,7 +69,6 @@ Integer2Test = TestCase (
     i := 1 << 70.
     self assert: Integer equals: i class.
     self assert: i > 0 description: 'should not overflow'.
-    self optional: #bigIntShifts assert: '1180591620717411303424' equals: i asString.
 
     i := -1 << 30.
     self assert: Integer equals: i class.
@@ -94,7 +88,6 @@ Integer2Test = TestCase (
     i := -1 << 70.
     self assert: Integer equals: i class.
     self assert: i < 0 description: 'should not underflow'.
-    self optional: #bigIntShifts assert: '-1180591620717411303424' equals: i asString.
   )
 
   testStringConversion = (
@@ -107,18 +100,16 @@ Integer2Test = TestCase (
     self assert: 42 equals: '42' asInteger.
     self assert: -2 equals: '-2' asInteger.
   )
-  
+
   testIntegerLiterals = (
     "Make sure the parser reads literals correctly. So, check some basic properties"
     self assert: 2 / 2                                     equals:                       1.
     self assert: 50 + 50                                   equals:                     100.
     self assert: 92233720368 * 100000000 + 54775807        equals:     9223372036854775807.
-    self assert: 92233720368 * 100000000 + 54775807 * 100  equals:   922337203685477580700.
     self assert: 50 - 100                                  equals:                     -50.
     self assert: 21474 * -100000 - 83648                   equals:             -2147483648.
-    self assert: 92233720368 * 100000000 + 54775807 * -100 equals:  -922337203685477580700.
   )
-  
+
   testFromString = (
     self assert:                      1 equals: (Integer fromString:                      '1').
     self assert:                    100 equals: (Integer fromString:                    '100').
@@ -282,22 +273,14 @@ Integer2Test = TestCase (
     self assert: 0   equals:    1 >>> 1.
     self assert: 512 equals: 1024 >>> 1.
     self assert: 127 equals: 1023 >>> 3.
-
-    "not sure whether we should really insist on this"
-    self optional: #toBeSpecified assert: 9223372036854775807 equals:    -1 >>> 1.
-    self optional: #toBeSpecified assert: 9223372036854775296 equals: -1024 >>> 1.
   )
 
   testMin = (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
 
     big doIndexes: [:i |
       self assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
@@ -308,12 +291,8 @@ Integer2Test = TestCase (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
     big doIndexes: [:i |
       self assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
       self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ]

--- a/Examples/Benchmarks/TestSuite/Integer3Test.som
+++ b/Examples/Benchmarks/TestSuite/Integer3Test.som
@@ -38,13 +38,8 @@ Integer3Test = TestCase (
     "Sometimes it can be hard to implement efficiently, but it SHOULD really
      be true for all values of integers."
     a := 1 << 30.  b := 1 << 30.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 32.  b := 1 << 32.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 60.  b := 1 << 60.
-    self optional: #integerIdentity assert: a is: b.
   )
 
   testClassAndValueRanges = (
@@ -74,7 +69,6 @@ Integer3Test = TestCase (
     i := 1 << 70.
     self assert: Integer equals: i class.
     self assert: i > 0 description: 'should not overflow'.
-    self optional: #bigIntShifts assert: '1180591620717411303424' equals: i asString.
 
     i := -1 << 30.
     self assert: Integer equals: i class.
@@ -94,7 +88,6 @@ Integer3Test = TestCase (
     i := -1 << 70.
     self assert: Integer equals: i class.
     self assert: i < 0 description: 'should not underflow'.
-    self optional: #bigIntShifts assert: '-1180591620717411303424' equals: i asString.
   )
 
   testStringConversion = (
@@ -107,18 +100,16 @@ Integer3Test = TestCase (
     self assert: 42 equals: '42' asInteger.
     self assert: -2 equals: '-2' asInteger.
   )
-  
+
   testIntegerLiterals = (
     "Make sure the parser reads literals correctly. So, check some basic properties"
     self assert: 2 / 2                                     equals:                       1.
     self assert: 50 + 50                                   equals:                     100.
     self assert: 92233720368 * 100000000 + 54775807        equals:     9223372036854775807.
-    self assert: 92233720368 * 100000000 + 54775807 * 100  equals:   922337203685477580700.
     self assert: 50 - 100                                  equals:                     -50.
     self assert: 21474 * -100000 - 83648                   equals:             -2147483648.
-    self assert: 92233720368 * 100000000 + 54775807 * -100 equals:  -922337203685477580700.
   )
-  
+
   testFromString = (
     self assert:                      1 equals: (Integer fromString:                      '1').
     self assert:                    100 equals: (Integer fromString:                    '100').
@@ -282,22 +273,14 @@ Integer3Test = TestCase (
     self assert: 0   equals:    1 >>> 1.
     self assert: 512 equals: 1024 >>> 1.
     self assert: 127 equals: 1023 >>> 3.
-
-    "not sure whether we should really insist on this"
-    self optional: #toBeSpecified assert: 9223372036854775807 equals:    -1 >>> 1.
-    self optional: #toBeSpecified assert: 9223372036854775296 equals: -1024 >>> 1.
   )
 
   testMin = (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
 
     big doIndexes: [:i |
       self assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
@@ -308,12 +291,8 @@ Integer3Test = TestCase (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
     big doIndexes: [:i |
       self assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
       self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ]

--- a/Examples/Benchmarks/TestSuite/Integer4Test.som
+++ b/Examples/Benchmarks/TestSuite/Integer4Test.som
@@ -38,13 +38,8 @@ Integer4Test = TestCase (
     "Sometimes it can be hard to implement efficiently, but it SHOULD really
      be true for all values of integers."
     a := 1 << 30.  b := 1 << 30.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 32.  b := 1 << 32.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 60.  b := 1 << 60.
-    self optional: #integerIdentity assert: a is: b.
   )
 
   testClassAndValueRanges = (
@@ -74,7 +69,6 @@ Integer4Test = TestCase (
     i := 1 << 70.
     self assert: Integer equals: i class.
     self assert: i > 0 description: 'should not overflow'.
-    self optional: #bigIntShifts assert: '1180591620717411303424' equals: i asString.
 
     i := -1 << 30.
     self assert: Integer equals: i class.
@@ -94,7 +88,6 @@ Integer4Test = TestCase (
     i := -1 << 70.
     self assert: Integer equals: i class.
     self assert: i < 0 description: 'should not underflow'.
-    self optional: #bigIntShifts assert: '-1180591620717411303424' equals: i asString.
   )
 
   testStringConversion = (
@@ -107,18 +100,16 @@ Integer4Test = TestCase (
     self assert: 42 equals: '42' asInteger.
     self assert: -2 equals: '-2' asInteger.
   )
-  
+
   testIntegerLiterals = (
     "Make sure the parser reads literals correctly. So, check some basic properties"
     self assert: 2 / 2                                     equals:                       1.
     self assert: 50 + 50                                   equals:                     100.
     self assert: 92233720368 * 100000000 + 54775807        equals:     9223372036854775807.
-    self assert: 92233720368 * 100000000 + 54775807 * 100  equals:   922337203685477580700.
     self assert: 50 - 100                                  equals:                     -50.
     self assert: 21474 * -100000 - 83648                   equals:             -2147483648.
-    self assert: 92233720368 * 100000000 + 54775807 * -100 equals:  -922337203685477580700.
   )
-  
+
   testFromString = (
     self assert:                      1 equals: (Integer fromString:                      '1').
     self assert:                    100 equals: (Integer fromString:                    '100').
@@ -282,22 +273,14 @@ Integer4Test = TestCase (
     self assert: 0   equals:    1 >>> 1.
     self assert: 512 equals: 1024 >>> 1.
     self assert: 127 equals: 1023 >>> 3.
-
-    "not sure whether we should really insist on this"
-    self optional: #toBeSpecified assert: 9223372036854775807 equals:    -1 >>> 1.
-    self optional: #toBeSpecified assert: 9223372036854775296 equals: -1024 >>> 1.
   )
 
   testMin = (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
 
     big doIndexes: [:i |
       self assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
@@ -308,12 +291,8 @@ Integer4Test = TestCase (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
     big doIndexes: [:i |
       self assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
       self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ]

--- a/Examples/Benchmarks/TestSuite/Integer5Test.som
+++ b/Examples/Benchmarks/TestSuite/Integer5Test.som
@@ -38,13 +38,8 @@ Integer5Test = TestCase (
     "Sometimes it can be hard to implement efficiently, but it SHOULD really
      be true for all values of integers."
     a := 1 << 30.  b := 1 << 30.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 32.  b := 1 << 32.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 60.  b := 1 << 60.
-    self optional: #integerIdentity assert: a is: b.
   )
 
   testClassAndValueRanges = (
@@ -74,7 +69,6 @@ Integer5Test = TestCase (
     i := 1 << 70.
     self assert: Integer equals: i class.
     self assert: i > 0 description: 'should not overflow'.
-    self optional: #bigIntShifts assert: '1180591620717411303424' equals: i asString.
 
     i := -1 << 30.
     self assert: Integer equals: i class.
@@ -94,7 +88,6 @@ Integer5Test = TestCase (
     i := -1 << 70.
     self assert: Integer equals: i class.
     self assert: i < 0 description: 'should not underflow'.
-    self optional: #bigIntShifts assert: '-1180591620717411303424' equals: i asString.
   )
 
   testStringConversion = (
@@ -107,18 +100,16 @@ Integer5Test = TestCase (
     self assert: 42 equals: '42' asInteger.
     self assert: -2 equals: '-2' asInteger.
   )
-  
+
   testIntegerLiterals = (
     "Make sure the parser reads literals correctly. So, check some basic properties"
     self assert: 2 / 2                                     equals:                       1.
     self assert: 50 + 50                                   equals:                     100.
     self assert: 92233720368 * 100000000 + 54775807        equals:     9223372036854775807.
-    self assert: 92233720368 * 100000000 + 54775807 * 100  equals:   922337203685477580700.
     self assert: 50 - 100                                  equals:                     -50.
     self assert: 21474 * -100000 - 83648                   equals:             -2147483648.
-    self assert: 92233720368 * 100000000 + 54775807 * -100 equals:  -922337203685477580700.
   )
-  
+
   testFromString = (
     self assert:                      1 equals: (Integer fromString:                      '1').
     self assert:                    100 equals: (Integer fromString:                    '100').
@@ -282,22 +273,14 @@ Integer5Test = TestCase (
     self assert: 0   equals:    1 >>> 1.
     self assert: 512 equals: 1024 >>> 1.
     self assert: 127 equals: 1023 >>> 3.
-
-    "not sure whether we should really insist on this"
-    self optional: #toBeSpecified assert: 9223372036854775807 equals:    -1 >>> 1.
-    self optional: #toBeSpecified assert: 9223372036854775296 equals: -1024 >>> 1.
   )
 
   testMin = (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
 
     big doIndexes: [:i |
       self assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
@@ -308,12 +291,8 @@ Integer5Test = TestCase (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
     big doIndexes: [:i |
       self assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
       self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ]

--- a/Examples/Benchmarks/TestSuite/IntegerTest.som
+++ b/Examples/Benchmarks/TestSuite/IntegerTest.som
@@ -38,13 +38,8 @@ IntegerTest = TestCase (
     "Sometimes it can be hard to implement efficiently, but it SHOULD really
      be true for all values of integers."
     a := 1 << 30.  b := 1 << 30.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 32.  b := 1 << 32.
-    self optional: #integerIdentity assert: a is: b.
-
     a := 1 << 60.  b := 1 << 60.
-    self optional: #integerIdentity assert: a is: b.
   )
 
   testClassAndValueRanges = (
@@ -74,7 +69,6 @@ IntegerTest = TestCase (
     i := 1 << 70.
     self assert: Integer equals: i class.
     self assert: i > 0 description: 'should not overflow'.
-    self optional: #bigIntShifts assert: '1180591620717411303424' equals: i asString.
 
     i := -1 << 30.
     self assert: Integer equals: i class.
@@ -94,7 +88,6 @@ IntegerTest = TestCase (
     i := -1 << 70.
     self assert: Integer equals: i class.
     self assert: i < 0 description: 'should not underflow'.
-    self optional: #bigIntShifts assert: '-1180591620717411303424' equals: i asString.
   )
 
   testStringConversion = (
@@ -107,18 +100,16 @@ IntegerTest = TestCase (
     self assert: 42 equals: '42' asInteger.
     self assert: -2 equals: '-2' asInteger.
   )
-  
+
   testIntegerLiterals = (
     "Make sure the parser reads literals correctly. So, check some basic properties"
     self assert: 2 / 2                                     equals:                       1.
     self assert: 50 + 50                                   equals:                     100.
     self assert: 92233720368 * 100000000 + 54775807        equals:     9223372036854775807.
-    self assert: 92233720368 * 100000000 + 54775807 * 100  equals:   922337203685477580700.
     self assert: 50 - 100                                  equals:                     -50.
     self assert: 21474 * -100000 - 83648                   equals:             -2147483648.
-    self assert: 92233720368 * 100000000 + 54775807 * -100 equals:  -922337203685477580700.
   )
-  
+
   testFromString = (
     self assert:                      1 equals: (Integer fromString:                      '1').
     self assert:                    100 equals: (Integer fromString:                    '100').
@@ -282,22 +273,14 @@ IntegerTest = TestCase (
     self assert: 0   equals:    1 >>> 1.
     self assert: 512 equals: 1024 >>> 1.
     self assert: 127 equals: 1023 >>> 3.
-
-    "not sure whether we should really insist on this"
-    self optional: #toBeSpecified assert: 9223372036854775807 equals:    -1 >>> 1.
-    self optional: #toBeSpecified assert: 9223372036854775296 equals: -1024 >>> 1.
   )
 
   testMin = (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
 
     big doIndexes: [:i |
       self assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
@@ -308,12 +291,8 @@ IntegerTest = TestCase (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 -50 -2147483648).
+    small := #(0  52 -51 -2147483650).
     big doIndexes: [:i |
       self assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
       self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ]

--- a/Examples/Benchmarks/TestSuite/Super2Test.som
+++ b/Examples/Benchmarks/TestSuite/Super2Test.som
@@ -50,35 +50,35 @@ Super2Test = SuperTestSuperClass (
   number = (
     ^ 10
   )
-  
+
   + other = (
     ^ 11
   )
-  
+
   ++++ other = (
     ^ 111
   )
-  
+
   keyword: other = (
     ^ 1111
   )
-  
+
   testBasicUnary = (
     self assert: 10 equals: self number.
     self assert:  1 equals: super number.
   )
-  
+
   testBasicBinary = (
     self assert: 11 equals: self + 3.
     self assert: 22 equals: super + 5.
   )
-  
-  
+
+
   testBasicBinaryNonStandardOperator = (
     self assert: 111 equals: self ++++ 3.
     self assert: 222 equals: super ++++ 5.
   )
-  
+
   testBasicKeyword = (
     self assert: 1111 equals: (self keyword: 3).
     self assert: 2222 equals: (super keyword: 5).
@@ -115,8 +115,6 @@ Super2Test = SuperTestSuperClass (
     | that |
     that := self.
     system global: #self put: 42.
-    that optional: #selfSuperBug assert: that is: self.
-
     self assert: 42 equals: (system global: #self)
   )
 
@@ -124,8 +122,6 @@ Super2Test = SuperTestSuperClass (
     | that |
     that := super.
     system global: #super put: 42.
-    that optional: #selfSuperBug assert: that is: super.
-
     self assert: 42 equals: (system global: #super)
   )
 )

--- a/Examples/Benchmarks/TestSuite/Super3Test.som
+++ b/Examples/Benchmarks/TestSuite/Super3Test.som
@@ -50,35 +50,35 @@ Super3Test = SuperTestSuperClass (
   number = (
     ^ 10
   )
-  
+
   + other = (
     ^ 11
   )
-  
+
   ++++ other = (
     ^ 111
   )
-  
+
   keyword: other = (
     ^ 1111
   )
-  
+
   testBasicUnary = (
     self assert: 10 equals: self number.
     self assert:  1 equals: super number.
   )
-  
+
   testBasicBinary = (
     self assert: 11 equals: self + 3.
     self assert: 22 equals: super + 5.
   )
-  
-  
+
+
   testBasicBinaryNonStandardOperator = (
     self assert: 111 equals: self ++++ 3.
     self assert: 222 equals: super ++++ 5.
   )
-  
+
   testBasicKeyword = (
     self assert: 1111 equals: (self keyword: 3).
     self assert: 2222 equals: (super keyword: 5).
@@ -115,8 +115,6 @@ Super3Test = SuperTestSuperClass (
     | that |
     that := self.
     system global: #self put: 42.
-    that optional: #selfSuperBug assert: that is: self.
-
     self assert: 42 equals: (system global: #self)
   )
 
@@ -124,8 +122,6 @@ Super3Test = SuperTestSuperClass (
     | that |
     that := super.
     system global: #super put: 42.
-    that optional: #selfSuperBug assert: that is: super.
-
     self assert: 42 equals: (system global: #super)
   )
 )

--- a/Examples/Benchmarks/TestSuite/Super4Test.som
+++ b/Examples/Benchmarks/TestSuite/Super4Test.som
@@ -50,35 +50,35 @@ Super4Test = SuperTestSuperClass (
   number = (
     ^ 10
   )
-  
+
   + other = (
     ^ 11
   )
-  
+
   ++++ other = (
     ^ 111
   )
-  
+
   keyword: other = (
     ^ 1111
   )
-  
+
   testBasicUnary = (
     self assert: 10 equals: self number.
     self assert:  1 equals: super number.
   )
-  
+
   testBasicBinary = (
     self assert: 11 equals: self + 3.
     self assert: 22 equals: super + 5.
   )
-  
-  
+
+
   testBasicBinaryNonStandardOperator = (
     self assert: 111 equals: self ++++ 3.
     self assert: 222 equals: super ++++ 5.
   )
-  
+
   testBasicKeyword = (
     self assert: 1111 equals: (self keyword: 3).
     self assert: 2222 equals: (super keyword: 5).
@@ -115,8 +115,6 @@ Super4Test = SuperTestSuperClass (
     | that |
     that := self.
     system global: #self put: 42.
-    that optional: #selfSuperBug assert: that is: self.
-
     self assert: 42 equals: (system global: #self)
   )
 
@@ -124,8 +122,6 @@ Super4Test = SuperTestSuperClass (
     | that |
     that := super.
     system global: #super put: 42.
-    that optional: #selfSuperBug assert: that is: super.
-
     self assert: 42 equals: (system global: #super)
   )
 )

--- a/Examples/Benchmarks/TestSuite/Super5Test.som
+++ b/Examples/Benchmarks/TestSuite/Super5Test.som
@@ -50,35 +50,35 @@ Super5Test = SuperTestSuperClass (
   number = (
     ^ 10
   )
-  
+
   + other = (
     ^ 11
   )
-  
+
   ++++ other = (
     ^ 111
   )
-  
+
   keyword: other = (
     ^ 1111
   )
-  
+
   testBasicUnary = (
     self assert: 10 equals: self number.
     self assert:  1 equals: super number.
   )
-  
+
   testBasicBinary = (
     self assert: 11 equals: self + 3.
     self assert: 22 equals: super + 5.
   )
-  
-  
+
+
   testBasicBinaryNonStandardOperator = (
     self assert: 111 equals: self ++++ 3.
     self assert: 222 equals: super ++++ 5.
   )
-  
+
   testBasicKeyword = (
     self assert: 1111 equals: (self keyword: 3).
     self assert: 2222 equals: (super keyword: 5).
@@ -115,8 +115,6 @@ Super5Test = SuperTestSuperClass (
     | that |
     that := self.
     system global: #self put: 42.
-    that optional: #selfSuperBug assert: that is: self.
-
     self assert: 42 equals: (system global: #self)
   )
 
@@ -124,8 +122,6 @@ Super5Test = SuperTestSuperClass (
     | that |
     that := super.
     system global: #super put: 42.
-    that optional: #selfSuperBug assert: that is: super.
-
     self assert: 42 equals: (system global: #super)
   )
 )

--- a/Examples/Benchmarks/TestSuite/SuperTest.som
+++ b/Examples/Benchmarks/TestSuite/SuperTest.som
@@ -50,35 +50,35 @@ SuperTest = SuperTestSuperClass (
   number = (
     ^ 10
   )
-  
+
   + other = (
     ^ 11
   )
-  
+
   ++++ other = (
     ^ 111
   )
-  
+
   keyword: other = (
     ^ 1111
   )
-  
+
   testBasicUnary = (
     self assert: 10 equals: self number.
     self assert:  1 equals: super number.
   )
-  
+
   testBasicBinary = (
     self assert: 11 equals: self + 3.
     self assert: 22 equals: super + 5.
   )
-  
-  
+
+
   testBasicBinaryNonStandardOperator = (
     self assert: 111 equals: self ++++ 3.
     self assert: 222 equals: super ++++ 5.
   )
-  
+
   testBasicKeyword = (
     self assert: 1111 equals: (self keyword: 3).
     self assert: 2222 equals: (super keyword: 5).
@@ -115,8 +115,6 @@ SuperTest = SuperTestSuperClass (
     | that |
     that := self.
     system global: #self put: 42.
-    that optional: #selfSuperBug assert: that is: self.
-
     self assert: 42 equals: (system global: #self)
   )
 
@@ -124,8 +122,6 @@ SuperTest = SuperTestSuperClass (
     | that |
     that := super.
     system global: #super put: 42.
-    that optional: #selfSuperBug assert: that is: super.
-
     self assert: 42 equals: (system global: #super)
   )
 )

--- a/Examples/Benchmarks/TestSuite/System2Test.som
+++ b/Examples/Benchmarks/TestSuite/System2Test.som
@@ -1,11 +1,5 @@
 System2Test = TestCase (
 
-  testFullGCSupport = (
-    "Test whether #fullGC is support. We expect the VM now to return true,
-     to indicate the a GC was done."
-    self optional: #fullGCWithEffect assert: system fullGC description: '#fullGC is not supported or has not immediate effect.'
-  )
-
   testTicks = (
     | ticks |
     ticks := system ticks.

--- a/Examples/Benchmarks/TestSuite/System3Test.som
+++ b/Examples/Benchmarks/TestSuite/System3Test.som
@@ -1,11 +1,5 @@
 System3Test = TestCase (
 
-  testFullGCSupport = (
-    "Test whether #fullGC is support. We expect the VM now to return true,
-     to indicate the a GC was done."
-    self optional: #fullGCWithEffect assert: system fullGC description: '#fullGC is not supported or has not immediate effect.'
-  )
-
   testTicks = (
     | ticks |
     ticks := system ticks.

--- a/Examples/Benchmarks/TestSuite/System4Test.som
+++ b/Examples/Benchmarks/TestSuite/System4Test.som
@@ -1,11 +1,5 @@
 System4Test = TestCase (
 
-  testFullGCSupport = (
-    "Test whether #fullGC is support. We expect the VM now to return true,
-     to indicate the a GC was done."
-    self optional: #fullGCWithEffect assert: system fullGC description: '#fullGC is not supported or has not immediate effect.'
-  )
-
   testTicks = (
     | ticks |
     ticks := system ticks.

--- a/Examples/Benchmarks/TestSuite/System5Test.som
+++ b/Examples/Benchmarks/TestSuite/System5Test.som
@@ -1,11 +1,5 @@
 System5Test = TestCase (
 
-  testFullGCSupport = (
-    "Test whether #fullGC is support. We expect the VM now to return true,
-     to indicate the a GC was done."
-    self optional: #fullGCWithEffect assert: system fullGC description: '#fullGC is not supported or has not immediate effect.'
-  )
-
   testTicks = (
     | ticks |
     ticks := system ticks.

--- a/Examples/Benchmarks/TestSuite/SystemTest.som
+++ b/Examples/Benchmarks/TestSuite/SystemTest.som
@@ -1,11 +1,5 @@
 SystemTest = TestCase (
 
-  testFullGCSupport = (
-    "Test whether #fullGC is support. We expect the VM now to return true,
-     to indicate the a GC was done."
-    self optional: #fullGCWithEffect assert: system fullGC description: '#fullGC is not supported or has not immediate effect.'
-  )
-
   testTicks = (
     | ticks |
     ticks := system ticks.

--- a/Examples/Benchmarks/TestSuite/TestCase.som
+++ b/Examples/Benchmarks/TestSuite/TestCase.som
@@ -27,28 +27,6 @@ TestCase = (
              description: [self comparingStringBetween: expected and: actual]
     )
 
-    optional: aSymbol assert: aBoolean = (
-        runner countAssert.
-        aBoolean ifFalse: [
-            self signalUnsupported: aSymbol description: nil ] )
-
-    optional: aSymbol assert: expected equals: actual = (
-        self optional: aSymbol
-             assert: (expected = actual)
-             description: [self comparingStringBetween: expected and: actual]
-    )
-
-    optional: aSymbol assert: expected is: actual = (
-        self optional: aSymbol
-             assert: (expected == actual)
-             description: [self comparingStringBetween: expected and: actual]
-    )
-
-    optional: aSymbol assert: aBoolean description: aStringOrBlock = (
-        runner countAssert.
-        aBoolean ifFalse: [
-            self signalUnsupported: aSymbol description: aStringOrBlock value ] )
-
     deny: aBoolean = (
         self assert: aBoolean not
     )
@@ -57,24 +35,10 @@ TestCase = (
         self assert: aBooleanOrBlock value not description: aString
     )
 
-    optional: aSymbol deny: aBoolean = (
-        self optional: aSymbol assert: aBoolean not
-    )
-
-    optional: aSymbol deny: aBooleanOrBlock description: aString = (
-        self optional: aSymbol assert: aBooleanOrBlock value not description: aString
-    )
-
     signalFailure: aString = (
         failed := true.
         runner fail: self class name + '>>#' + testSelector
             because: aString.
-    )
-
-    signalUnsupported: aSymbol description: aDescription = (
-        runner unsupported: aSymbol
-                      test: self class name + '>>#' + testSelector
-                   because: aDescription.
     )
 
     comparingStringBetween: expected and: actual = (

--- a/Examples/Benchmarks/TestSuite/TestCommon.som
+++ b/Examples/Benchmarks/TestSuite/TestCommon.som
@@ -24,8 +24,6 @@ THE SOFTWARE.
 "
 
 TestCommon = Benchmark (
-    | failOnUnsupportedOptionals |
-
     tests = ( "Now ordered by alphabetical order to improve maintainability"
         self error: 'Implement in subclass'
     )
@@ -40,9 +38,8 @@ TestCommon = Benchmark (
     )
 
     runAllSuites = (
-      | totalTestNum successfulTestNum unsupportedTestNum totalAssertionNum arr |
+      | totalTestNum successfulTestNum totalAssertionNum arr |
       totalTestNum := 0.
-      unsupportedTestNum := 0.
       successfulTestNum := 0.
       totalAssertionNum := 0.
 
@@ -53,14 +50,13 @@ TestCommon = Benchmark (
         runner runAllTests.
 
         totalTestNum       := totalTestNum + runner expectedPasses.
-        unsupportedTestNum := unsupportedTestNum + runner actualUnsupported.
         successfulTestNum  := successfulTestNum + runner actualPasses.
         totalAssertionNum  := totalAssertionNum + runner numAsserts.
       ].
 
       arr := Array new: 4.
       arr at: 1 put: totalTestNum.
-      arr at: 2 put: unsupportedTestNum.
+      arr at: 2 put: 0. "was 'unsupported', but for the benchmark, I removed this to be able to run on all VMs"
       arr at: 3 put: successfulTestNum.
       arr at: 4 put: totalAssertionNum.
       ^ arr
@@ -79,16 +75,15 @@ TestCommon = Benchmark (
     )
 
     benchmark = (
-        failOnUnsupportedOptionals := false.
         ^ self runAllSuites
     )
 
     verifyResult: result = (
-      "result do: [:e | e println ]."
-      ^ (result at: 1) = (190 * self numExecs) and: [
+      "result do: [:e | e print. '  // numExecs: ' print. (e // self numExecs) println ]."
+      ^ (result at: 1) = (189 * self numExecs) and: [
           (result at: 2) = (0 * self numExecs) and: [
-            (result at: 3) = (190 * self numExecs) and: [
-              (result at: 4) = (992 * self numExecs)
+            (result at: 3) = (189 * self numExecs) and: [
+              (result at: 4) = (958 * self numExecs)
         ] ] ]
     )
 )

--- a/Examples/Benchmarks/TestSuite/TestGCCommon.som
+++ b/Examples/Benchmarks/TestSuite/TestGCCommon.som
@@ -21,21 +21,18 @@ THE SOFTWARE.
 "
 
 TestGCCommon = Benchmark (
-    | failOnUnsupportedOptionals |
-
     tests = ( "Now ordered by alphabetical order to improve maintainability"
         self error: 'Implement in subclass'
     )
-    
+
     oneTimeSetup = (
       "Load all Tests. We don't really want to benchmark the parser."
       self tests
     )
 
     runAllSuites = (
-      | totalTestNum successfulTestNum unsupportedTestNum totalAssertionNum arr |
+      | totalTestNum successfulTestNum totalAssertionNum arr |
       totalTestNum := 0.
-      unsupportedTestNum := 0.
       successfulTestNum := 0.
       totalAssertionNum := 0.
 
@@ -46,14 +43,13 @@ TestGCCommon = Benchmark (
         runner runAllTests.
 
         totalTestNum       := totalTestNum + runner expectedPasses.
-        unsupportedTestNum := unsupportedTestNum + runner actualUnsupported.
         successfulTestNum  := successfulTestNum + runner actualPasses.
         totalAssertionNum  := totalAssertionNum + runner numAsserts.
       ].
 
       arr := Array new: 4.
       arr at: 1 put: totalTestNum.
-      arr at: 2 put: unsupportedTestNum.
+      arr at: 2 put: 0. "was 'unsupported', but for the benchmark, I removed this to be able to run on all VMs"
       arr at: 3 put: successfulTestNum.
       arr at: 4 put: totalAssertionNum.
       ^ arr
@@ -70,11 +66,11 @@ TestGCCommon = Benchmark (
       runner run.
       runner hasFailures ifTrue: [system exit: 1]
     )
-    
+
     benchmark = (
       ^ system fullGC
     )
-    
+
     verifyResult: result = (
       "We expect the GC to actually promise us that it did work"
       ^ result

--- a/Examples/Benchmarks/TestSuite/TestRunner.som
+++ b/Examples/Benchmarks/TestSuite/TestRunner.som
@@ -1,22 +1,21 @@
 TestRunner = (
-  | suite passes unsupported failures numAsserts |
+  | suite passes failures numAsserts |
 
   initializeOn: aSuite = (
     suite := aSuite.
 
     passes       := Vector new.
-    unsupported  := Vector new.
     failures     := Vector new.
 
     numAsserts := 0.
   )
 
-  hasUnsupported  = ( ^ unsupported size > 0 )
   hasFailures     = ( ^ failures size > 0 )
-
-  actualUnsupported = ( ^ unsupported size )
   expectedPasses = ( ^ suite tests size )
   actualPasses   = ( ^ passes size )
+
+  hasUnsupported  = ( ^ false )
+  actualUnsupported = ( ^ 0 )
 
   run = (
     self reportPreRun.
@@ -39,9 +38,6 @@ TestRunner = (
   )
 
   reportPostRun = (
-    self hasUnsupported ifTrue: [
-      ('Unsupported optional: ' + unsupported size asString) println
-    ].
     self hasFailures ifTrue: [
       ('Failures: ' + failures size asString) println
     ].
@@ -55,21 +51,8 @@ TestRunner = (
   overviewReport = (
     ('Tests passed: ' + passes size asString) println.
 
-    (self hasFailures or: [self hasUnsupported]) ifTrue: [
+    self hasFailures ifTrue: [
         '------------------------------' println ].
-
-    self hasUnsupported ifTrue: [
-      | lastCategory |
-      ('Unsupported optional features: ' + unsupported size asString) println.
-      unsupported do: [:each |
-        | cat |
-        cat := each at: 1.
-        cat == lastCategory ifFalse: [
-          lastCategory := cat.
-          ('\t' + cat) println ].
-        ('\t\t' + (each at: 2) asString) println.
-        ('\t\t\t' + (each at: 3) value asString) println ].
-    ].
 
     self hasFailures ifTrue: [
       ('Failures: ' + failures size asString) println.
@@ -83,12 +66,6 @@ TestRunner = (
     | pair |
     pair := Pair withKey: aSignature andValue: aReason.
     failures append: pair.
-  )
-
-  unsupported: aSymbol test: aSignature because: aReason = (
-    | array |
-    array := Array with: aSymbol with: aSignature with: aReason.
-    unsupported append: array.
   )
 
   passed: aSignature = (


### PR DESCRIPTION
SOM++ had been removed from the CI setup as part of #118, but it's now in a better shape and can be enabled again.

Though, the Test benchmark was still testing optional features, and unsupported things.
To make sure the benchmark runs identically on all SOM implementations, this PR removes the optional assertions, and also avoids testing for larger numbers, which may not be supported by some SOMs, incl. SOM++, which still doesn't have arbitrarily large integers. 