### PR TITLE
Add test for writing to undefined identifier and parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Black, PyLint and PyTest
         run: |
@@ -109,7 +109,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout SOM Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout SOM VM Repository
         if: matrix.som != 'spec'

--- a/IntegrationTests/Tests/parse_and_methods.som
+++ b/IntegrationTests/Tests/parse_and_methods.som
@@ -1,0 +1,67 @@
+"
+VM:
+  status: success
+  stdout:
+    parse_and_methods#run
+    parse_and_methods#---
+    parse_and_methods#func2
+    Integer#+
+    Integer#-
+    Integer#*
+    Integer#/
+    Integer#//
+    Integer#%
+    Integer#rem:
+    Integer#&
+    Integer#<<
+    Integer#>>>
+    Integer#bitXor:
+    Integer#abs
+    Integer#sqrt
+    Integer#negated
+    Integer#raisedTo:
+    Integer#atRandom
+    Integer#=
+    Integer#==
+    Integer#~=
+    Integer#<
+    Integer#>
+    Integer#>=
+    Integer#<=
+    Integer#negative
+    Integer#between:and:
+    Integer#asString
+    Integer#as32BitSignedValue
+    Integer#as32BitUnsignedValue
+    Integer#asDouble
+    Integer#asInteger
+    Integer#hashcode
+    Integer#to:do:
+    Integer#to:by:do:
+    Integer#downTo:do:
+    Integer#downTo:by:do:
+    Integer#timesRepeat:
+    Integer#to:
+    Integer#max:
+    Integer#min:
+"
+
+parse_and_methods = (
+  run = (
+    parse_and_methods methods do: [ :meth |
+        meth holder print.
+        meth signature println.
+    ].
+    Integer methods do: [ :meth |
+        meth holder print.
+        meth signature println.
+    ].
+  )
+  ---
+  func = (
+    1 println.
+  )
+  func2 = (
+    2 println.
+  )
+)

--- a/IntegrationTests/Tests/unknown_field_write2.som
+++ b/IntegrationTests/Tests/unknown_field_write2.som
@@ -1,0 +1,16 @@
+"
+VM:
+  status: error
+  stderr:
+    ...
+    No such field 'c' in class
+"
+
+unknown_field_write2 = (
+  run = (
+    | b |
+    b := [ 1 println. ].
+    c := [ 2 println. ].
+    b whileTrue: c.
+  )
+)


### PR DESCRIPTION
This PR adds two tests based on https://github.com/SOM-st/SOMpp/issues/65

- parse_and_methods.som: tests that the parser correctly takes `---` as a method name instead of the instance/class separator and that we can print the methods and their holders in two classes. The printing caused a segfault on SOM++ because the holder was not correctly set

- unknown_field_write2.som: another test for writing to an undefined identifier. SOM++ had a wrong assertion for this case

I don't expect to merge this any time soon, since this requires updating all SOMs. And I should really have a more uniform error format.